### PR TITLE
[#49] Use calculated data to check for advantage boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.  The format
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones). 
 
-- *Changed* Set Token Vision and Light macro to use Normal Vision range if Night Vision is selected but the token does not have it. In fact, it sets the Dim Light range to the higher of the default Normal Vision range and the calculated Dim Vision range, which would be 0 if the token doesn't have Night Vision.  
+- *Changed* Set Token Vision and Light macro to use Normal Vision range if Night Vision is selected but the token does not have it. In fact, it sets the Dim Light range to the higher of the default Normal Vision range and the calculated Dim Vision range, which would be 0 if the token doesn't have Night Vision.
+- *Fixed* a bug that could prevent advantage macros from updating or capping correctly. 
 
 ## Version 0.6
 

--- a/scripts/advantage.js
+++ b/scripts/advantage.js
@@ -1,6 +1,6 @@
 function getBaseActor(token) {
     if (token.data.actorLink) {
-        return getActor = token.actor._data; // use linked actor
+        return getActor = token.actor.data; // use linked actor
     } else {
         return getActor = token.data.actorData; // use synthetic actor
     }
@@ -12,9 +12,9 @@ function getResourceBase(actor,baseActor) {
     let resourceMax = Number();
     if (resourceData !== undefined && resourceData.status !== undefined && resourceData.status.advantage !== undefined) {
             resourceCurrent = Number(resourceData.status.advantage.value);
-            resourceMax = resourceData.status.advantage.max | actor._data.data.status.advantage.max;
+            resourceMax = resourceData.status.advantage.max | actor.data.data.status.advantage.max;
         } else {
-            resourceMax = actor._data.data.status.advantage.max;
+            resourceMax = actor.data.data.status.advantage.max;
             // console.log("No status defined. Setting current value to " + resourceCurrent)
         } 
     return {"current":resourceCurrent, "max":resourceMax}; 


### PR DESCRIPTION
token.actor.data applies settings and game rules to base data (token.actor._data) to determine whether the token/actor has either 0 or maximum advantage. This is needed to correctly determine advantage thresholds and apply a decrease or increase respectively.

Fixes #49