### PR TITLE
Add RollTable compatibility for Token Hud Extension shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ All notable changes to this project will be documented in this file.  The format
 
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones). 
-- *Changed* Foundry compatibility to up to ###. WFRP4e system compatibility is up to ###. 
-- *Fix* non-rendered html in Marginal Success roll description.
-- *Fixed* issue where module settings could not be accessed ([#70](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/70)).
-- *Changed* Send Dark Whispers macro to be compatible with WFRP4e v5.0.4 ([#69](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/69))
-- *Added* Dark Whispers RollTable and compendium for use by Send Dark Whispers macro. Added prompt to import table in Send Dark Whispers dialog if not present. 
-
+- *Changed* Foundry compatibility to ###. WFRP4e system compatibility is ###. 
+- *Fixed* non-rendered html in Marginal Success roll description.
+- *Fixed* issue where module settings could not be accessed [[#70](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/70)].
+- *Added* RollTable compatibility to the Send Dark Whispers macro. This fixes issues with "undefined" Dark Whisper text in the Send Dark Whispers dialog [[#69](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/69)].
+- *Added* Dark Whispers RollTable from compendium for use by Send Dark Whispers macro. 
+- *Added* prompt to import table in Send Dark Whispers dialog if not present. 
+- *Added* RollTable compatibility to Token Hud Extensions. This fixes issues with rolling for Mental Corruption, Physical Mutation and Wrath of the Gods using Token Hud Extension shortcuts. [[#69](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/69)]. 
+- *Changed* Token Hud shortcut for Mental Corruption from `CTRL+SHIFT+double-click` to `SHIFT+double-click`.
+- *Added* message prompt to install Mental Corruption, Physical Mutation and Wrath of the Gods Rolltables if not present. 
 
 ## Version 0.8.0
 - *Changed* Advantage scripts to handle non-token characters. 

--- a/lang/en.json
+++ b/lang/en.json
@@ -22,6 +22,8 @@
     "GMTOOLKIT.TokenHudExtension.StatusChanged" : "{targetStatus} changed from {originalStatus} to {newStatus} for {targetName}",
     "GMTOOLKIT.TokenHudExtension.StatusNotChanged" : "{targetStatus} is unchanged at {originalStatus} for {targetName}",
     "GMTOOLKIT.TokenHudExtension.LittlePrayerResult" : "<p>{actorName} offered a Little Prayer to the Gods ({littlePrayerResult}).</p>",
+    "GMTOOLKIT.TokenHudExtension.ImportTable" : "{table} table not found. Please import from the Compendium.",
+    "GMTOOLKIT.TokenHudExtension.Sufferance" : "{actor} suffers {plight}",
   
     "GMTOOLKIT.Dialog.Apply": "Apply Changes",    
     "GMTOOLKIT.Dialog.Cancel" : "Cancel",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -22,6 +22,8 @@
     "GMTOOLKIT.TokenHudExtension.StatusChanged" : "{targetStatus} est passé de {originalStatus} à {newStatus} pour {targetName}",
     "GMTOOLKIT.TokenHudExtension.StatusNotChanged" : "{targetStatus} demeure à {originalStatus} pourr {targetName}",
     "GMTOOLKIT.TokenHudExtension.LittlePrayerResult" : "<p>{actorName} a offert une Modeste Prière aux Dieux ({littlePrayerResult}).</p>",
+    "GMTOOLKIT.TokenHudExtension.ImportTable" : "{table} table not found. Please import from the Compendium.",
+    "GMTOOLKIT.TokenHudExtension.Sufferance" : "{actor} suffers {plight}",
 
     "GMTOOLKIT.Dialog.Apply" : "Appliquer les changements",
     "GMTOOLKIT.Dialog.Cancel" : "Annuler",

--- a/modules/token-hud-extension.mjs
+++ b/modules/token-hud-extension.mjs
@@ -351,14 +351,6 @@ export default class TokenHudExtension {
             })            
             hudCorruption.find("i").dblclick(async (ev) => {
                 GMToolkit.log(false, `Corruption hud extension double-clicked.`)
-                if (ev.ctrlKey && ev.shiftKey && wfrp4eContent.core) {
-                    let result = game.wfrp4e.tables.formatChatRoll("mutatemental");
-                    ChatMessage.create(game.wfrp4e.utility.chatDataSetup(result, "roll", true));
-                    GMToolkit.log(false, `${actor.name} spawned a mental mutation.`) 
-                    ev.preventDefault();
-                    ev.stopPropagation();
-                    return;
-                }
                 if (ev.ctrlKey && ev.altKey) {
                     let littlePrayer = new Roll("d100") 
                     littlePrayer.roll();
@@ -370,17 +362,28 @@ export default class TokenHudExtension {
                     return;
                 }
                 if (ev.shiftKey && ev.altKey && wfrp4eContent.core) {
-                    let result = game.wfrp4e.tables.formatChatRoll("wrath");
-                    ChatMessage.create(game.wfrp4e.utility.chatDataSetup(result, "roll", true));
-                    GMToolkit.log(false, `${actor.name} incurred the Wrath of the Gods.`) 
+                    let result = (game.tables.getName("Wrath of the Gods Table")) ? await game.wfrp4e.tables.rollTable("wrath") : `${game.i18n.format("GMTOOLKIT.TokenHudExtension.ImportTable", {table: "Wrath of the Gods"})}`
+                    let chatData = game.wfrp4e.utility.chatDataSetup(result?.result || result, "gmroll", true)
+                    chatData.flavor = game.i18n.format("GMTOOLKIT.TokenHudExtension.Sufferance", {actor: actor.name, plight: "the Wrath of the Gods"})
+                    ChatMessage.create(chatData, {});  
                     ev.preventDefault();
                     ev.stopPropagation();
                     return;
                 }
                 if (ev.ctrlKey && wfrp4eContent.core) {
-                    let result = game.wfrp4e.tables.formatChatRoll("mutatephys");
-                    ChatMessage.create(game.wfrp4e.utility.chatDataSetup(result, "roll", true));
-                    GMToolkit.log(false, `${actor.name} spawned a physical mutation.`) 
+                    let result = (game.tables.getName("Physical Mutation")) ? await game.wfrp4e.tables.rollTable("mutatephys") : `${game.i18n.format("GMTOOLKIT.TokenHudExtension.ImportTable", {table: "Physical Mutation"})}`
+                    let chatData = game.wfrp4e.utility.chatDataSetup(result?.result || result, "gmroll", true)
+                    chatData.flavor = game.i18n.format("GMTOOLKIT.TokenHudExtension.Sufferance", {actor: actor.name, plight: "Physical Mutation"})
+                    ChatMessage.create(chatData, {});  
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    return;
+                }
+                if (ev.shiftKey && wfrp4eContent.core) {
+                    let result = (game.tables.getName("Mental Corruption")) ? await game.wfrp4e.tables.rollTable("mutatemental") : `${game.i18n.format("GMTOOLKIT.TokenHudExtension.ImportTable", {table: "Mental Corruption"})}`
+                    let chatData = game.wfrp4e.utility.chatDataSetup(result?.result || result, "gmroll", true)
+                    chatData.flavor = game.i18n.format("GMTOOLKIT.TokenHudExtension.Sufferance", {actor: actor.name, plight: "Mental Corruption"})
+                    ChatMessage.create(chatData, {});  
                     ev.preventDefault();
                     ev.stopPropagation();
                     return;


### PR DESCRIPTION
- Added RollTable compatibility to Token Hud Extensions, fixing issues with rolling for Mental Corruption, Physical Mutation and Wrath of the Gods using Token Hud Extension shortcuts. #69. 
- Changed Token Hud shortcut for Mental Corruption from `CTRL+SHIFT+double-click` to `SHIFT+double-click`.
- Added message prompt to install Mental Corruption, Physical Mutation and Wrath of the Gods Rolltables if not present. 