### PR TITLE
Use actors and tokens for Dark Whisper target selection #58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,13 @@ See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
   - Tokens and combatants are always considered `present` on a given scene.
   - The functionality can be accessed in macros and functions with `game.gmtoolkit.utility.getGroup(groupType, {options})`. 
 - *Changed* **Add XP** and **Reset Fortune** macros to use group selection. Default "party" selection enforces that a character must be assigned to a player. 
-- *Changed* **Send Dark Whispers** macro to use group selection. 
+- *Changed* **Send Dark Whispers** macro to use group selection, enabling selection by actor rather than player. 
   - Default "party" selection enforces that a character must be assigned to a player. [[#58](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/58)].
-  - Added option to send a whisper to each player owner rather than just the assigned player. 
+  - *Added* an option to send a dark whisper to each player owner rather than just the assigned player. 
   - Hovering over the character name lists all player owners as well as the assigned player. 
-  - THe option to set default targets for Dark Whispers has been removed. Instead, all party members are shown. Any that are targeted in the viewed scene are pre-checked. 
+- *Removed* the module setting to define default targets for Dark Whispers has been removed. 
+  - Instead, all party members are listed in the Send Dark Whispers dialog.  
+  - Any eligible actor tokens that are targeted in the scene are pre-checked.
 
 ## [Version 0.9.3](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/v0.9.3)  (2022-05-25)
 - *Fixed* missing Token Hud Extension options for players who don't have access to configure tokens. The layout of Token Hud Extensions has been reorganised as a result of this change. [[#67](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/67)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,12 @@ See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
   - Actors that are not assigned to players (eg, NPCs) are removed from `active` filtered results, but will appear in unfiltered results if appropriate.
   - Tokens and combatants are always considered `present` on a given scene.
   - The functionality can be accessed in macros and functions with `game.gmtoolkit.utility.getGroup(groupType, {options})`. 
-- *Changed* **Add XP** and **Reset Fortune** macros to use group selection. Default "party" selection enforces that a character must be assigned to a player.
+- *Changed* **Add XP** and **Reset Fortune** macros to use group selection. Default "party" selection enforces that a character must be assigned to a player. 
+- *Changed* **Send Dark Whispers** macro to use group selection. 
+  - Default "party" selection enforces that a character must be assigned to a player. [[#58](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/58)].
+  - Added option to send a whisper to each player owner rather than just the assigned player. 
+  - Hovering over the character name lists all player owners as well as the assigned player. 
+  - THe option to set default targets for Dark Whispers has been removed. Instead, all party members are shown. Any that are targeted in the viewed scene are pre-checked. 
 
 ## [Version 0.9.3](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/v0.9.3)  (2022-05-25)
 - *Fixed* missing Token Hud Extension options for players who don't have access to configure tokens. The layout of Token Hud Extensions has been reorganised as a result of this change. [[#67](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/67)]

--- a/lang/en.json
+++ b/lang/en.json
@@ -190,6 +190,8 @@
     "GMTOOLKIT.Dialog.DarkWhispers.NoCorruption" : "No Corruption to spend on offer.", 
     "GMTOOLKIT.Dialog.DarkWhispers.HasCorruption" : "Someone to bargain with.", 
     "GMTOOLKIT.Dialog.DarkWhispers.ImportTable" : "Import the Dark Whispers RollTable from the GM Toolkit compendium to see Dark Whisper prompts here.", 
+    "GMTOOLKIT.Dialog.DarkWhispers.PlayerTooltip" : "Assigned to: {assignedUser}\nOwned by: {playerOwners}", 
+    "GMTOOLKIT.Dialog.DarkWhispers.SendToOwners" : "Send to all Player Owners (not only Assigned User).", 
     
     "GMTOOLKIT.Message.DarkWhispers.Accept" : "Heed the Whisper", 
     "GMTOOLKIT.Message.DarkWhispers.Reject" : "Deny the Dark Gods", 

--- a/lang/en.json
+++ b/lang/en.json
@@ -173,11 +173,6 @@
     "GMTOOLKIT.Settings.DarkWhispers.menu.label" : "Configure Dark Whispers",
     "GMTOOLKIT.Settings.DarkWhispers.menu.hint" : "Set default options for Send Dark Whispers macro.",
     "GMTOOLKIT.Settings.DarkWhispers.menu.title" : "Dark Whispers Settings",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.name" : "Dark Whispers Targets",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.hint" : "Set the default filter to select characters to receive a Dark Whisper. Override this by setting a parameter in the macro for 'all', 'present' or 'absent' party members.",
-	"GMTOOLKIT.Settings.DarkWhispers.Filter.All" : "All party members (default)",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.Absent" : "Logged out party members only",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.Present" : "Logged in party members only",
 
     "GMTOOLKIT.Message.DarkWhispers.NoPermission" : "Only GMs can send Dark Whispers!",
     "GMTOOLKIT.Message.DarkWhispers.NoEligibleCharacters" : "No available characters have Corruption to exchange for a Dark Whisper.", 

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -173,11 +173,6 @@
     "GMTOOLKIT.Settings.DarkWhispers.menu.label" : "Configure Dark Whispers",
     "GMTOOLKIT.Settings.DarkWhispers.menu.hint" : "Set default options for Send Dark Whispers macro.",
     "GMTOOLKIT.Settings.DarkWhispers.menu.title" : "Dark Whispers Settings",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.name" : "Cibles des Sombres murmures",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.hint" : "Définit le filtre par défaut pour sélectionner les Personnages recevant un Sombre murmure. Vous pouvez écraser ce paramètre en le définissant directement dans la macro en \"all\", \"present\" ou \"absent\".",
-	"GMTOOLKIT.Settings.DarkWhispers.Filter.All" : "Tous les membres du groupe (par défaut)",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.Absent" : "Membres déconnectés du groupe seulement",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.Present" : "Membres connectés du groupe seulement",
 
     "GMTOOLKIT.Message.DarkWhispers.NoPermission" : "Seuls les MJ peuvent envoyer des Sombres murmures !",
     "GMTOOLKIT.Message.DarkWhispers.NoEligibleCharacters" : "Aucun Personnage disponible n'a de Corruption à troquer contre un Sombre murmure.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -190,6 +190,8 @@
     "GMTOOLKIT.Dialog.DarkWhispers.NoCorruption" : "No Corruption to spend on offer.", 
     "GMTOOLKIT.Dialog.DarkWhispers.HasCorruption" : "Someone to bargain with.", 
     "GMTOOLKIT.Dialog.DarkWhispers.ImportTable" : "Import the Dark Whispers RollTable from the GM Toolkit compendium to see Dark Whisper prompts here.", 
+    "GMTOOLKIT.Dialog.DarkWhispers.PlayerTooltip" : "Assigned to: {assignedUser}\nOwned by: {playerOwners}", 
+    "GMTOOLKIT.Dialog.DarkWhispers.SendToOwners" : "Send to all Player Owners (not only Assigned User).",
     
     "GMTOOLKIT.Message.DarkWhispers.Accept" : "Obéir au Murmure",
     "GMTOOLKIT.Message.DarkWhispers.Reject" : "Ignorer les Dieux Noirs",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -173,11 +173,6 @@
     "GMTOOLKIT.Settings.DarkWhispers.menu.label" : "「闇の囁き」設定",
     "GMTOOLKIT.Settings.DarkWhispers.menu.hint" : "「闇の囁き」送信マクロオプションの既定値を設定する。",
     "GMTOOLKIT.Settings.DarkWhispers.menu.title" : "「闇の囁き」設定",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.name" : "「闇の囁き」の宛先",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.hint" : "「闇の囁き」送信先キャラクタを選択する既定のフィルタを設定する。マクロの「all」、「present」と「absent」を設定で上書きする。",
-	"GMTOOLKIT.Settings.DarkWhispers.Filter.All" : "パーティメンバー全員（既定値）",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.Absent" : "ログアウトしたパーティメンバーに限定",
-    "GMTOOLKIT.Settings.DarkWhispers.Filter.Present" : "ログイン中のパーティメンバーに限定",
 
     "GMTOOLKIT.Message.DarkWhispers.NoPermission" : "「闇の囁き」を送ることが出来るのはGMだけです！",
     "GMTOOLKIT.Message.DarkWhispers.NoEligibleCharacters" : "「闇の囁き」と交換できる堕落しているキャラクターは居ない。",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -190,6 +190,8 @@
     "GMTOOLKIT.Dialog.DarkWhispers.NoCorruption" : "No Corruption to spend on offer.",
     "GMTOOLKIT.Dialog.DarkWhispers.HasCorruption" : "Someone to bargain with.",
     "GMTOOLKIT.Dialog.DarkWhispers.ImportTable" : "GM Toolkitの事典から「闇の囁き表」をインポートすると、ここで「闇の囁き表」の文面を見ることが出来ます。",
+    "GMTOOLKIT.Dialog.DarkWhispers.PlayerTooltip" : "Assigned to: {assignedUser}\nOwned by: {playerOwners}", 
+    "GMTOOLKIT.Dialog.DarkWhispers.SendToOwners" : "Send to all Player Owners (not only Assigned User).",
 
     "GMTOOLKIT.Message.DarkWhispers.Accept" : "囁きを受け入れる",
     "GMTOOLKIT.Message.DarkWhispers.Reject" : "闇の神々を拒絶する",

--- a/modules/gm-toolkit-settings.mjs
+++ b/modules/gm-toolkit-settings.mjs
@@ -245,20 +245,6 @@ export default class GMToolkitSettings {
             restricted: true                 
         });
         // Settings for Send Dark Whispers Macro
-        game.settings.register(GMToolkit.MODULE_ID, "targetDarkWhispers", {
-            name: "GMTOOLKIT.Settings.DarkWhispers.Filter.name",
-            hint: "GMTOOLKIT.Settings.DarkWhispers.Filter.hint",
-            scope: "world",
-            config: false,
-            default: "all",
-            type: String,
-            choices: {
-                "all": "GMTOOLKIT.Settings.DarkWhispers.Filter.All",
-                "present": "GMTOOLKIT.Settings.DarkWhispers.Filter.Present",
-                "absent": "GMTOOLKIT.Settings.DarkWhispers.Filter.Absent",
-            },
-            feature: "darkwhispers"
-        });
         game.settings.register(GMToolkit.MODULE_ID, "messageDarkWhispers", {
             name: "GMTOOLKIT.Settings.DarkWhispers.message.name",
             hint: "GMTOOLKIT.Settings.DarkWhispers.message.hint",

--- a/scripts/macros/dark-whispers.js
+++ b/scripts/macros/dark-whispers.js
@@ -7,7 +7,9 @@ async function formDarkWhispers() {
   }
 
   // setup: determine group of actors to be whispered to 
-  const group = game.user.targets.size < 1 ? game.gmtoolkit.utility.getGroup("party") : game.gmtoolkit.utility.getGroup("party", {interaction : "targeted"});
+  // const group = game.user.targets.size < 1 ? game.gmtoolkit.utility.getGroup("party") : game.gmtoolkit.utility.getGroup("party", {interaction : "targeted"});
+  const group =  game.gmtoolkit.utility.getGroup("party");
+  const targeted = game.gmtoolkit.utility.getGroup("party", {interaction : "targeted"});
   // setup: exit with notice if there are no player-assigned characters
   if (!group) {   
     return ui.notifications.error(game.i18n.localize("GMTOOLKIT.Message.DarkWhispers.NoEligibleCharacters"));
@@ -29,7 +31,8 @@ async function formDarkWhispers() {
         max: g.data.data?.status?.corruption?.max
       }, 
       assignedUser: game.users.players.filter(p => p.character === g)[0],
-      owners : game.users.players.filter(p => p.id in g.data.permission)
+      owners : game.users.players.filter(p => p.id in g.data.permission),
+      targeted : targeted.includes(g)
     })
   });
 
@@ -37,10 +40,11 @@ async function formDarkWhispers() {
   let checkOptions = "";
   characterList.forEach(actor => {
     let canWhisperTo = (actor.corruption.value) ? `enabled title="${game.i18n.localize('GMTOOLKIT.Dialog.DarkWhispers.HasCorruption')}"` : `disabled title="${game.i18n.localize('GMTOOLKIT.Dialog.DarkWhispers.NoCorruption')}"`;
+    let checked = (actor.targeted && actor.corruption.value) ? "checked" : "";
     let playerOwners = actor.owners.map(m => m.name).join(", ")
     checkOptions +=`
       <div class="form-group">
-      <input type="checkbox" id="${actor.actorId}" name="${actor.actorId}" value="${actor.name}" ${canWhisperTo}>
+      <input type="checkbox" id="${actor.actorId}" name="${actor.actorId}" value="${actor.name}" ${canWhisperTo} ${checked}>
       <label for="${actor.actorId}" title="${game.i18n.format('GMTOOLKIT.Dialog.DarkWhispers.PlayerTooltip', {assignedUser: actor.assignedUser.name, playerOwners: playerOwners})}"> <strong>${actor.name}</strong> (${actor.assignedUser.name})</label>
       <label for="${actor.actorId}"> ${actor.corruption.value} / ${actor.corruption.max} ${game.i18n.localize("GMTOOLKIT.Status.Corruption")} </label>
       </div>
@@ -133,4 +137,5 @@ function abortWhisper() {
 * TIP: Only player-assigned characters with Corruption can be sent a Dark Whisper. 
 * TIP: The placeholder whisper is drawn from the Dark Whispers table. Change this for different random whispers. 
 * TIP: The whisper can be edited in the dialog, regardless of what is pre-filled from the Dark Whispers table. 
+* TIP: Actor tokens that are targeted in a scene are pre-selecteed in the Send Dark Whisper dialog.
 ========== */

--- a/scripts/macros/dark-whispers.js
+++ b/scripts/macros/dark-whispers.js
@@ -1,62 +1,56 @@
-formDarkWhispers(); //  Set default user target filter in module settings. Override by adding parameter to "all", "absent" or "present" party members. Clear parameter to revert to default. 
+formDarkWhispers(); 
 
-async function formDarkWhispers(targets=String(game.settings.get("wfrp4e-gm-toolkit", "targetDarkWhispers"))) {
-// Non-GMs are not permitted to send Dark Whispers
+async function formDarkWhispers() {
+  // Non-GMs are not permitted to send Dark Whispers
   if (!game.user.isGM) {      
     return ui.notifications.error(game.i18n.localize("GMTOOLKIT.Message.DarkWhispers.NoPermission"));
   }
 
-  //TODO: Switch to actor based selection
-  // Only users who have an assigned player character are available to whisper to. 
-  let users = []
-  switch (targets) { 
-    case "all":
-      users = game.users.filter(user => (user.character?.type == "character"));
-      break;
-  case "absent":
-      users = game.users.filter(user => !user.active && (user.character?.type == "character"));
-      break;
-  case "present":
-  default:
-     users = game.users.filter(user => user.active && (user.character?.type == "character"));
-     break;
-  }
-
-  if (!users) {   
+  // setup: determine group of actors to be whispered to 
+  const group = game.user.targets.size < 1 ? game.gmtoolkit.utility.getGroup("party") : game.gmtoolkit.utility.getGroup("party", {interaction : "targeted"});
+  // setup: exit with notice if there are no player-assigned characters
+  if (!group) {   
     return ui.notifications.error(game.i18n.localize("GMTOOLKIT.Message.DarkWhispers.NoEligibleCharacters"));
   }
-  
-  // Build list of player / characters to select via dialog
-  //TODO: Map individual Corruption values, rather than increment
-  let corruptionAvailable = 0; // count to check there are characters with corruption to target
-  let checkOptions = "";
-  users.forEach(user => {
-    let actorCorruption = {
-      value: game.actors.get(user.character.id).data.data.status.corruption.value, 
-      max: game.actors.get(user.character.id).data.data.status.corruption.max
-    };
-    corruptionAvailable += actorCorruption.value;
-    // Make unselectable if character has no Corruption to deal with
-    let canWhisperTo = (actorCorruption.value) ? `enabled title="${game.i18n.localize('GMTOOLKIT.Dialog.DarkWhispers.HasCorruption')}"` : `disabled title="${game.i18n.localize('GMTOOLKIT.Dialog.DarkWhispers.NoCorruption')}"`;
+  // setup: exit with notice if there are no player-assigned characters with Corruption
+  if (!group.some(g => g.data.data?.status?.corruption?.value > 0)) {
+    return ui.notifications.error(game.i18n.localize("GMTOOLKIT.Message.DarkWhispers.NoEligibleCharacters"));
+  }
 
-    checkOptions+=`
-        <div class="form-group">
-        <input type="checkbox" name="${user.id}" value="${user.name}" ${canWhisperTo}>
-        <label for="${user.id}"> <strong>${user.character.name}</strong> (${user.name})</label>
-        <label for="${user.id}"> ${actorCorruption.value} / ${actorCorruption.max} ${game.i18n.localize("GMTOOLKIT.Status.Corruption")} </label>
-        </div>
-      `
+  // Setup dialog content
+  // Build list of characters to select via dialog
+  const characterList = []
+  group.forEach(g => { 
+    characterList.push({
+      actorId: g?.actor?.id || g.id, 
+      name: g?.actor?.name || g.name, 
+      corruption: {
+        value: g.data.data?.status?.corruption?.value, 
+        max: g.data.data?.status?.corruption?.max
+      }, 
+      assignedUser: game.users.players.filter(p => p.character === g)[0],
+      owners : game.users.players.filter(p => p.id in g.data.permission)
+    })
   });
-  
-  // abort if no characters have any Corruption
-  if (corruptionAvailable == 0) {   
-    return ui.notifications.error(game.i18n.localize("GMTOOLKIT.Message.DarkWhispers.NoEligibleCharacters"));
-  };
 
-  // Construct and show form to write whisper message and select target player characters
+  // Build dialog content
+  let checkOptions = "";
+  characterList.forEach(actor => {
+    let canWhisperTo = (actor.corruption.value) ? `enabled title="${game.i18n.localize('GMTOOLKIT.Dialog.DarkWhispers.HasCorruption')}"` : `disabled title="${game.i18n.localize('GMTOOLKIT.Dialog.DarkWhispers.NoCorruption')}"`;
+    let playerOwners = actor.owners.map(m => m.name).join(", ")
+    checkOptions +=`
+      <div class="form-group">
+      <input type="checkbox" id="${actor.actorId}" name="${actor.actorId}" value="${actor.name}" ${canWhisperTo}>
+      <label for="${actor.actorId}" title="${game.i18n.format('GMTOOLKIT.Dialog.DarkWhispers.PlayerTooltip', {assignedUser: actor.assignedUser.name, playerOwners: playerOwners})}"> <strong>${actor.name}</strong> (${actor.assignedUser.name})</label>
+      <label for="${actor.actorId}"> ${actor.corruption.value} / ${actor.corruption.max} ${game.i18n.localize("GMTOOLKIT.Status.Corruption")} </label>
+      </div>
+    `
+  });
+
+  // Construct and show form
   let darkwhisper = (game.tables.getName(game.i18n.localize("GMTOOLKIT.Dialog.DarkWhispers.Title"))) ? await game.wfrp4e.tables.rollTable("darkwhispers") : game.i18n.format("GMTOOLKIT.Dialog.DarkWhispers.ImportTable")
 
- let dialogContent = `
+  let dialogContent = `
     <div class="form-group ">
       <label for="targets">${game.i18n.localize("GMTOOLKIT.Dialog.DarkWhispers.WhisperTargets")} </label>
     </div>
@@ -67,63 +61,74 @@ async function formDarkWhispers(targets=String(game.settings.get("wfrp4e-gm-tool
     <div class="form-group">
       <textarea id="message" name="message" rows="4" cols="50">${darkwhisper?.result || darkwhisper}</textarea>
     </div>
-    `
- new Dialog({
-  title: game.i18n.localize("GMTOOLKIT.Dialog.DarkWhispers.Title"),
-  content:dialogContent,
-  buttons:{
-    whisper:{   
-      label: game.i18n.localize("GMTOOLKIT.Dialog.DarkWhispers.SendWhisper"),
-      callback: (html) => sendDarkWhispers(html, users, "private")
+    <div class="form-group">
+      <input type="checkbox" id="sendToOwners" name="sendToOwners">
+      <label for="sendToOwners">${game.i18n.localize("GMTOOLKIT.Dialog.DarkWhispers.SendToOwners")}</label>
+    </div>
+  `
+
+  new Dialog({
+    title: game.i18n.localize("GMTOOLKIT.Dialog.DarkWhispers.Title"),
+    content:dialogContent,
+    buttons: {
+      cancel: {   
+        label: game.i18n.localize("GMTOOLKIT.Dialog.Cancel"),
+        callback: (html) => abortWhisper()
+      },
+      whisper: {   
+        label: game.i18n.localize("GMTOOLKIT.Dialog.DarkWhispers.SendWhisper"),
+        callback: (html) => sendDarkWhispers(html, characterList, html.find('[name="sendToOwners"]')[0].checked)
+      }
     }
-  }
-}).render(true);
+    }).render(true);
 }
 
-function sendDarkWhispers(html, users, sendmode) {
-  // check for whisper message 
-  let messageText = html.find('[name="message"]')[0].value;
-  
-  // build list of selected players ids for whispers target
-  let targets = [];
-  for ( let user of users ) {
-    if (html.find(`[name="${user.id}"]`)[0].checked){
-      targets.push(user.id);
+function sendDarkWhispers(html, characterList, sendToOwners) {
+  // Build list of selected players ids for whispers target
+  let characterTargets = []; 
+  let playerRecipients = [];  
+
+  for ( let character of characterList ) {
+    if (html.find(`[name="${character.actorId}"]`)[0].checked) {
+      characterTargets.push(character.name);
+      sendToOwners ? playerRecipients.push(...character.owners.map(m => m.id)) : playerRecipients.push(character.assignedUser.id)
     }
   }
-
+    
+  // check for whisper message 
+  darkwhisper = html.find('[name="message"]')[0].value   
   // abort if no whisper or character is selected 
-  if (targets.length == 0 || messageText.length == 0) {
-    return ui.notifications.error(game.i18n.format("GMTOOLKIT.Message.DarkWhispers.WhisperAborted", {currentUser: game.users.current.name}));
-  }
+  if (!playerRecipients.length || !darkwhisper) return abortWhisper()
 
   // Construct and send message to whisper targets
   // Build the translation string based on the setting
-  let messageTemplate = `GMTOOLKIT.Settings.DarkWhispers.message.${game.settings.get("wfrp4e-gm-toolkit", "messageDarkWhispers")}`
+  const messageTemplate = `GMTOOLKIT.Settings.DarkWhispers.message.${game.settings.get("wfrp4e-gm-toolkit", "messageDarkWhispers")}`
   // Parse the translated message
-  let whisperMessage = `${game.i18n.format(messageTemplate, {message: messageText})}`
-  
-  // Add response buttons for chat card
-  // data- attributes are used by listener
-  let responseObjects = `
+  const whisperMessage = `${game.i18n.format(messageTemplate, {message: darkwhisper})}`
+  // Add response buttons for chat card. data- attributes are used by listener.
+  const responseButtons = `
     <span class="chat-card-button-area">
-    <a class="chat-card-button darkwhisper-button" data-button="actOnWhisper" data-ask="${game.i18n.format(messageText)}">${game.i18n.localize("GMTOOLKIT.Message.DarkWhispers.Accept")}</a>
-    <a class="chat-card-button darkwhisper-button" data-button="denyDarkGods" data-ask="${game.i18n.format(messageText)}">${game.i18n.localize("GMTOOLKIT.Message.DarkWhispers.Reject")}</a>
+    <a class="chat-card-button darkwhisper-button" data-button="actOnWhisper" data-ask="${game.i18n.format(darkwhisper)}">${game.i18n.localize("GMTOOLKIT.Message.DarkWhispers.Accept")}</a>
+    <a class="chat-card-button darkwhisper-button" data-button="denyDarkGods" data-ask="${game.i18n.format(darkwhisper)}">${game.i18n.localize("GMTOOLKIT.Message.DarkWhispers.Reject")}</a>
     </span>
     `
-
+  // Post the message 
   ChatMessage.create({
-    content: whisperMessage + responseObjects,
-    whisper: targets
+    content: whisperMessage + responseButtons,
+    whisper: playerRecipients, 
+    flavor: characterTargets.join(', ') 
   });
-  
+}
+
+function abortWhisper() {
+  return ui.notifications.error(game.i18n.format("GMTOOLKIT.Message.DarkWhispers.WhisperAborted", {currentUser: game.user.name}));
 }
 
 
 /* ==========
 * MACRO: Send Dark Whispers
-* VERSION: 0.9.2
-* UPDATED: 2022-01-04
+* VERSION: 0.9.4
+* UPDATED: 2022-07-04
 * DESCRIPTION: Open a dialog to send a Dark Whisper (WFRP p183) to one or more selected player character(s).
 * TIP: Only player-assigned characters with Corruption can be sent a Dark Whisper. 
 * TIP: The placeholder whisper is drawn from the Dark Whispers table. Change this for different random whispers. 


### PR DESCRIPTION
- Enforces assigned player requirement 
- Removes Dark Whisper Targets module setting
- Adds option to send whisper to all player owners