### PR TITLE
Prevent advantage gain if not initiating challenge #159

### DIFF
--- a/modules/advantage.mjs
+++ b/modules/advantage.mjs
@@ -406,25 +406,28 @@ Hooks.on("wfrp4e:opposedTestResult", async function (opposedTest, attackerTest, 
     .filter(c => c.actor === winner)[0]
     .token.object
   if (character.combatant.getFlag(GMToolkit.MODULE_ID, "advantage")?.opposed !== opposedTest.attackerTest.message.id) {
-    await Advantage.update(character, "increase", "wfrp4e:opposedTestResult")
-
-    if (!winner.ownership[game.user.id]) {
-      await game.socket.emit(`module.${GMToolkit.MODULE_ID}`, {
-        type: "setFlag",
-        payload: {
-          character: character.combatant,
-          updateData: {
-            flag: "advantage",
-            key: "opposed",
-            value: opposedTest.attackerTest.message.id
-          }
-        }
-      })
+    if (game.settings.get("wfrp4e", "useGroupAdvantage") === true && character.actor !== attacker) {
+      console.log("No advantage gained for winning an opposed test you did not initiate.")
     } else {
-      await character.combatant
-        .setFlag(GMToolkit.MODULE_ID, "advantage",
-          { opposed: opposedTest.attackerTest.message.id }
-        )
+      await Advantage.update(character, "increase", "wfrp4e:opposedTestResult")
+      if (!winner.ownership[game.user.id]) {
+        await game.socket.emit(`module.${GMToolkit.MODULE_ID}`, {
+          type: "setFlag",
+          payload: {
+            character: character.combatant,
+            updateData: {
+              flag: "advantage",
+              key: "opposed",
+              value: opposedTest.attackerTest.message.id
+            }
+          }
+        })
+      } else {
+        await character.combatant
+          .setFlag(GMToolkit.MODULE_ID, "advantage",
+            { opposed: opposedTest.attackerTest.message.id }
+          )
+      }
     }
   } else {
     console.log(`Advantage increase already applied to ${character.name} for winning opposed test.`)


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run linting on my code to follow the follow the [style](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/blob/dev/.eslintrc.json) of this project.
- [x] My changes generate no new unhandled or unexpected warnings.
- [x] My change requires an update to the [documentation](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/wiki).

## Related Issue(s) 
Fixes or addresses #issue #159.

## Description
### Motivation and context
Group Advantage rules in Up in Arms dictate that no advantage is gained for winning unless you initiate the test. 

### Summary of changes
Added additional exit condition if opposed test actor is not attacker when using Group Advantage.

### How has this been tested?
Execute opposed tests with Group Advantage on and off, where attacker and defender wins on different occasions. 

### Development / Testing Environment
- Foundry VTT: 10.279
- WFRP4e System: 6.1.0
- GM Toolkit:  v0.9.5

### Screen Capture
![image](https://user-images.githubusercontent.com/521096/187080365-ae9adc01-5d3f-43bf-a560-9a32b6432b2d.png)
