### PR TITLE
Show macro version from compendium in Toolkit Maintenance #176

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.  The format
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 * *Added* headline features to README to make it easier for users to get an overview of what's available in the Toolkit suite.
 * *Fixed* issue where Launch Damage Console was not translated in Toolkit Maintenance dialog. [#177](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/177)
+* *Fixed* issue where Toolkit Maintenance would not show compendium versions of macros. [#176](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/176)
 
 ## [Version 6.0.0](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/6.0.0)  (2022-09-06)
 - *Changed* Group Test setup form to clear or restore custom skill field if a skill is chosen from the skill list dropdown. [#160](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/160)

--- a/apps/gm-toolkit-maintenance.js
+++ b/apps/gm-toolkit-maintenance.js
@@ -72,7 +72,7 @@ async function buildLocalizedContent (documentType) {
   for (const content of toolkitContent) {
     content.translationKey = strip(content.name, translationKeyPrefix, ".")
     content.compendiumVersion = documents
-      .filter(d => d.id === content.id)
+      .filter(d => d.name === game.i18n.localize(content.translationKey))
       .map(i => i.flags["wfrp4e-gm-toolkit"].version)
     contentArray.push(content)
   }


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run linting on my code to follow the follow the [style](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/blob/dev/.eslintrc.json) of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new unhandled or unexpected warnings.
- [ ] My change requires an update to the [documentation](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/wiki).

## Related Issue(s) 
Fixes or addresses #issue(s): #176

## Description

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
It's not possible to tell whether world macros are out of date if compendium version is not shown. Therefore it;s not clear whether a (destructive) content import is required. 

### Summary of changes
Previously, compendium version was based on a match of document ID. Now this is switched to document name. This will rely on macro names in the world matching original names in the compendium.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of tests you ran to see how your change affects existing code. -->

### Development / Testing Environment
- Foundry VTT: 10.284
- WFRP4e System: 6.1.2
- GM Toolkit:  6.0.0
- Macro (if applicable): NA

### Screen Capture
![image](https://user-images.githubusercontent.com/521096/188996773-0d461344-7b69-4fc2-b958-63309a67cd7f.png)
