### PR TITLE
Add macro hotbar shortcut upgrade advice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.  The format
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 * *Added* headline features to README to make it easier for users to get an overview of what's available in the Toolkit suite.
+* *Added* advice about replacing macro hotbar shortcuts to avoid compatibility issues.
 * *Fixed* issue where Launch Damage Console was not translated in Toolkit Maintenance dialog. [#177](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/177)
 * *Fixed* issue where Toolkit Maintenance would not show compendium versions of macros. [#176](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/176)
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,18 @@ For previous versions, you should use:
 ## Installation Instructions
 For full details, see the [Getting Started guide](../../wiki/getting-started) on the [wiki](../../wiki). 
 
-1. Add via Add-on Modules tab of Foundry VTT setup.
+1. **Install the module** via the Add-on Modules tab of Foundry VTT setup.
    - Module Name: `GM Toolkit (WFRP4e)`
    - Manifest URL: https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/latest/download/module.json
-2. The GM needs to enable the module for the World:
+2. The GM needs to **enable the module** for the World:
    - `Settings` > `Manage Modules` > `GM Toolkit (WFRP 4e)`
-5. Import macros and tables through either
+3. **Import macros and tables** through either
    - [Toolkit Maintenance](../../wiki/toolkit-maintenance) option in `Settings` > `Module Settings` > `GM Toolkit (WFRP 4e)` > `Update GM Toolkit Content`.  Or
    - [manually importing](../../wiki/getting-started) from Compendium packs.
+4. Finally **replace hotbar shortcuts**. 
+   - These should be deleted automatically when using Toolkit Maintenance. 
+   - Replace shortcuts by dragging and dropping from the `GM Toolkit` `Macro Directory` to ensure they point to the latest versions. 
+   - If macros or shortcuts are not deleted automatically, be sure you don't have older copies of macros with the same names outside of the GM Toolkit folder. 
 
 ## References
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 
## Type of change
- [x] Documentation

## Related Issue(s) 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Identified as an issue as part of triage for #175.

## Description

### Motivation and context
In FVTT v10, macro hotbar shortbars are deleted but not replaced. If they are not automatically replaced, this indicates that potentially obsolete or conflicting macros exist that share the same name as imported macros. 

### Summary of changes
Adds installation step advice about replacing hotbar shortcuts. This is also reflected in the [Getting Started page of the wiki](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/wiki/getting-started). 

### How has this been tested?
Review README. 

### Development / Testing Environment
- Foundry VTT: 10.284
- WFRP4e System: 6.1.2
- GM Toolkit:  6.0.0
- Macro (if applicable): NA
