### PR TITLE
Enable Spectator notifications by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 * *Added* Polish localization. Thanks [@twisniowski](https://github.com/twisniowski) and [@silentmark](https://github.com/silentmark)! [#188](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/188)
 * *Fixed* error when applying damage or making ranged attacks outside of combat when using group advantage. Thanks [@silentmark](https://github.com/silentmark)! [`a186651`](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/188/commits/a186651)
 * *Added* version and download stat shields to README, to make it easy to see key install data for users and repo owners. [#190](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/190)
+* *Changed* module setting for Spectator notifications to *not* be suppressed by default. Unassigned characters are still being overlooked when experiencing issues with some macros that require an assigned actor. [#191](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/191)
 
 ## [Version 6.0.0](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/6.0.0)  (2022-09-06)
 - *Changed* Group Test setup form to clear or restore custom skill field if a skill is chosen from the skill list dropdown. [#160](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/160)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 * *Added* Polish localization. Thanks [@twisniowski](https://github.com/twisniowski) and [@silentmark](https://github.com/silentmark)! [#188](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/188)
 * *Fixed* error when applying damage or making ranged attacks outside of combat when using group advantage. Thanks [@silentmark](https://github.com/silentmark)! [`a186651`](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/188/commits/a186651)
 * *Added* version and download stat shields to README, to make it easy to see key install data for users and repo owners. [#190](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/190)
-* *Changed* module setting for Spectator notifications to *not* be suppressed by default. Unassigned characters are still being overlooked when experiencing issues with some macros that require an assigned actor. [#191](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/191)
+* *Fixed* module setting for Spectator notifications to *not* be suppressed by default. Unassigned characters are still being overlooked when experiencing issues with some macros that require an assigned actor. [#192](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/192)
 
 ## [Version 6.0.0](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/6.0.0)  (2022-09-06)
 - *Changed* Group Test setup form to clear or restore custom skill field if a skill is chosen from the skill list dropdown. [#160](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/160)

--- a/modules/gm-toolkit-settings.mjs
+++ b/modules/gm-toolkit-settings.mjs
@@ -312,10 +312,9 @@ export class GMToolkitSettings {
       hint: "GMTOOLKIT.Settings.Spectators.hint",
       scope: "world",
       config: true,
-      default: true,
+      default: false,
       type: Boolean,
-      onChange: debouncedReload,
-      feature: "grouptests"
+      onChange: debouncedReload
     })
 
     // Menu for Module Content Management
@@ -357,7 +356,6 @@ export function getDataSettings (data, feature) {
 
 export async function registerGroupTestSettings () {
   const skillList = await game.gmtoolkit.skills.reduce((skills, skill) => ({ ...skills, [`${game.i18n.localize(skill.name)}`]: `${game.i18n.localize(skill.name)}` }), {})
-  // GMToolkit.log(false, skillList)
 
   // Settings for Group Tests application
   game.settings.register(GMToolkit.MODULE_ID, "quicktest1GroupTest", {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run linting on my code to follow the follow the [style](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/blob/dev/.eslintrc.json) of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new unhandled or unexpected warnings.
- [ ] My change requires an update to the [documentation](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/wiki).

## Related Issue(s) 
Related to various Discord reports about macros affecting player-assigned actors not functioning as expected, as well as issue(s) #186 and #191 

## Description

### Motivation and context
Unassigned characters are still being overlooked when experiencing issues with some macros that require an assigned actor.  The feature is [originally documented](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/wiki/spectators#user-settings) as notifications being enabled by default to ensure that users are not caught out, but has actually been shipped as suppressed.

### Summary of changes
Updated setting default.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of tests you ran to see how your change affects existing code. -->
1. Set up a new world with at least one player, but without assigning an available PC actor to them.
2. Install and enable the GM Toolkit.
3. Relaunch the world and receive a Spectator notification. 


### Development / Testing Environment
- Foundry VTT: 10.286
- WFRP4e System: 6.1.41
- GM Toolkit:  6.0.0
