### PR TITLE
Bypass advantage cap if using Group Advantage #194

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 * *Fixed* error when applying damage or making ranged attacks outside of combat when using group advantage. Thanks [@silentmark](https://github.com/silentmark)! [`a186651`](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/188/commits/a186651)
 * *Added* version and download stat shields to README, to make it easy to see key install data for users and repo owners. [#190](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/190)
 * *Fixed* module setting for Spectator notifications to *not* be suppressed by default. Unassigned characters are still being overlooked when experiencing issues with some macros that require an assigned actor. [#192](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/192)
+* *Fixed* issue where the Add Advantage macro be capped when using Group Advantage. [#194](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/194)
 
 ## [Version 6.0.0](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/6.0.0)  (2022-09-06)
 - *Changed* Group Test setup form to clear or restore custom skill field if a skill is chosen from the skill list dropdown. [#160](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/160)

--- a/modules/advantage.mjs
+++ b/modules/advantage.mjs
@@ -70,7 +70,9 @@ export default class Advantage {
 
     switch (adjustment) {
       case "increase":
-        if (advantage.max === undefined || advantage.current < advantage.max) {
+        if (game.settings.get("wfrp4e", "useGroupAdvantage")
+          || advantage.max === undefined
+          || advantage.current < advantage.max) {
           advantage.new = Number(advantage.current + 1)
           const updated = await updateCharacterAdvantage()
           updated ? outcome = "increased" : outcome = "nochange"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run linting on my code to follow the follow the [style](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/blob/dev/.eslintrc.json) of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new unhandled or unexpected warnings.

## Related Issue(s) 
Fixes or addresses #issue(s): #194

## Description

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
There is no cap to how much Group Advantage can be accrued, unlike personal Advantage. 

### Summary of changes
<!-- Please include a summary of what behaviour/functionality has changed, been introduced or removed. -->
<!-- List any dependencies that are required for this change. --> 
Check first to see whether Group Advantage is being used when increasing Advantage through Toolkit functionality, and, if so, ignore any checks against the actor's max advantage and proceed with updating the pool. 

### How has this been tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of tests you ran to see how your change affects existing code. -->

### Development / Testing Environment
- Foundry VTT: 10.287
- WFRP4e System: 6.1.4
- GM Toolkit:  v6.0.0, dev:[6a93add](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/commit/f926e36652024b5c2d4afad9b7fdb3e9cf4c7dd7)

### Screen Capture
![image](https://user-images.githubusercontent.com/521096/194878423-42a94986-2c06-4040-ad8e-3ac0bb78e983.png)

