### PR TITLE
Edit chat message flavour text

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -314,6 +314,9 @@
     "GMTOOLKIT.Message.Welcome.UpdateMacros" : "Update Macros",
     "GMTOOLKIT.Message.Welcome.UpdateTables" : "Update Tables",
 
-    "GMTOOLKIT.Dialog.QuickSettings.Title" : "GM Toolkit Settings"
+    "GMTOOLKIT.Dialog.QuickSettings.Title" : "GM Toolkit Settings",
+
+    "GMTOOLKIT.ChatFlavour.Title" : "Edit Message Flavour",
+    "GMTOOLKIT.ChatFlavour.Placeholder" : "Briefly describe the message context"
 
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -314,6 +314,9 @@
     "GMTOOLKIT.Message.Welcome.UpdateMacros" : "Update Macros",
     "GMTOOLKIT.Message.Welcome.UpdateTables" : "Update Tables",
 
-    "GMTOOLKIT.Dialog.QuickSettings.Title" : "GM Toolkit Settings"
+    "GMTOOLKIT.Dialog.QuickSettings.Title" : "GM Toolkit Settings",
+
+    "GMTOOLKIT.ChatFlavour.Title" : "Edit Message Flavour",
+    "GMTOOLKIT.ChatFlavour.Placeholder" : "Briefly describe the message context"
 
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -314,6 +314,9 @@
     "GMTOOLKIT.Message.Welcome.UpdateMacros" : "Update Macros",
     "GMTOOLKIT.Message.Welcome.UpdateTables" : "Update Tables",
 
-    "GMTOOLKIT.Dialog.QuickSettings.Title" : "GM Toolkit Settings"
+    "GMTOOLKIT.Dialog.QuickSettings.Title" : "GM Toolkit Settings",
+
+    "GMTOOLKIT.ChatFlavour.Title" : "Edit Message Flavour",
+    "GMTOOLKIT.ChatFlavour.Placeholder" : "Briefly describe the message context"
 
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -314,6 +314,9 @@
     "GMTOOLKIT.Message.Welcome.UpdateMacros" : "Update Macros",
     "GMTOOLKIT.Message.Welcome.UpdateTables" : "Update Tables",
 
-    "GMTOOLKIT.Dialog.QuickSettings.Title" : "GM Toolkit Settings"
+    "GMTOOLKIT.Dialog.QuickSettings.Title" : "GM Toolkit Settings",
+
+    "GMTOOLKIT.ChatFlavour.Title" : "Edit Message Flavour",
+    "GMTOOLKIT.ChatFlavour.Placeholder" : "Briefly describe the message context"
 
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -314,6 +314,9 @@
     "GMTOOLKIT.Message.Welcome.UpdateMacros" : "Update Macros",
     "GMTOOLKIT.Message.Welcome.UpdateTables" : "Update Tables",
 
-    "GMTOOLKIT.Dialog.QuickSettings.Title" : "GM Toolkit Settings"
+    "GMTOOLKIT.Dialog.QuickSettings.Title" : "GM Toolkit Settings",
+
+    "GMTOOLKIT.ChatFlavour.Title" : "Edit Message Flavour",
+    "GMTOOLKIT.ChatFlavour.Placeholder" : "Briefly describe the message context"
     
 }

--- a/wfrp4e-gm-toolkit.mjs
+++ b/wfrp4e-gm-toolkit.mjs
@@ -178,3 +178,48 @@ export class SocketHandlers {
   }
 
 }
+
+/* -------------------------------------------- */
+/*  Entry Context                               */
+/* -------------------------------------------- */
+
+Hooks.on("getChatLogEntryContext", (html, options) => {
+  options.push(
+    {
+      name: game.i18n.localize("GMTOOLKIT.ChatFlavour.Title"),
+      icon: '<i class="fas fa-pen-fancy"></i>',
+      condition: game.user.isGM,
+      callback: li => {
+        let message = game.messages.get(li.attr("data-message-id"))
+        const flavor = new Dialog({
+          title: game.i18n.localize("GMTOOLKIT.ChatFlavour.Title"),
+          content: `<form>
+                <div class="form-group">
+                  <input type="text"
+                    id="message-flavor"
+                    name="message-flavor"
+                    placeholder="${game.i18n.localize("GMTOOLKIT.ChatFlavour.Placeholder")}"
+                    value="${message?.flavor}"
+                  />
+                </div>
+                </form>`,
+          buttons: {
+            submit: {
+              icon: "<i class='fas fa-check'></i>",
+              label: game.i18n.localize("GMTOOLKIT.Dialog.Apply"),
+              callback: async html => {
+                const messageFlavor = html.find("#message-flavor").val()
+                await message.update({ flavor: messageFlavor })
+              }
+            },
+            cancel: {
+              icon: "<i class='fas fa-times'></i>",
+              label: game.i18n.localize("GMTOOLKIT.Dialog.Cancel")
+            }
+          },
+          default: "submit"
+        }).render(true)
+      }
+    }
+  )
+})


### PR DESCRIPTION
Adds a context menu to chat messages for editing (including adding and clearing) flavour text.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Translation (updates existing localization strings or adds complete new language file)

## Checklist:
- [x] My change requires an update to the [documentation](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/wiki).

## Description

### Motivation and context
It is sometimes useful to add a note to a roll or other chat message, for additional detail, context or just as a reminder.

### Summary of changes
- New context menu hook added for "getChatLogEntryContext"
- 2 new translation strings: 
  - GMTOOLKIT.ChatFlavour.Title
  - GMTOOLKIT.ChatFlavour.Placeholder

### Development / Testing Environment
- Foundry VTT: 10.291
- WFRP4e System: 6.2.2
- GM Toolkit:  6.0.1

### Screen Capture
![chrome_6yRgZqkLwi](https://user-images.githubusercontent.com/521096/205944405-02f026f6-243c-46e1-a90c-5c8f83b8748f.gif)


