### PR TITLE
Prevent loss of Advantage when becoming Engaged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
+* *Added* compatibility with `Engaged` pseudo-condition, so that when a character becomes Engaged and this condition is added, they do not lose their Advantage. [#206](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/206)
 * *Added* a new context menu option to chat messages to edit flavour text. [#207](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/207)
 * *Added* a quick launch macro to easily access GM Toolkit Settings without having to navigate Foundry configuration menus. [#203](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/203)
 * *Fixed* issue where Add XP macro uses default group setting for Group Tests rather than Session Turnover. [#201](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/201)

--- a/modules/advantage.mjs
+++ b/modules/advantage.mjs
@@ -448,12 +448,13 @@ Hooks.on("createActiveEffect", async function (conditionEffect) {
   if (!game.user.isUniqueGM) return // ... not a GM
   if (!inActiveCombat(conditionEffect.parent, "silent")) return // ... not in combat
   if (!conditionEffect.isCondition) return  // ... not a system recognised condition
+  const nonConditions = ["dead", "fear", "grappling", "engaged"]
   const condId = conditionEffect.conditionId
-  if (condId === "dead" || condId === "fear" || condId === "grappling") return // ... not a core rules combat condition
+  if (nonConditions.includes(condId)) return // ... not a core rules combat condition
 
   // Clear Advantage
   const token = canvas.tokens.placeables.filter(
-    t => t.actor.id === conditionEffect.parent.id
+    t => conditionEffect.parent.id === (t?.actor?.id || t?.document?.id)
   )[0]
   await Advantage.update(token, "clear", "createActiveEffect")
 


### PR DESCRIPTION
Adds compatibility with [Engaged pseudo-condition](https://github.com/moo-man/WFRP4e-FoundryVTT/pull/1330), so that when a character gains the Engaged condition, they do not lose their Advantage. 
 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:->
- [x] I have run linting on my code to follow the follow the [style](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/blob/dev/.eslintrc.json) of this project.
- [x] My changes generate no new unhandled or unexpected warnings.
- [x] My change requires an update to the [documentation](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/wiki).

## Related Issue(s) 
Fixes or addresses #issue(s): #206

## Description

### Motivation and context
Token actors would incorrectly lose Advantage when gaining the `Engaged` condition, introduced in WFRP4e 6.2.0.

### Summary of changes
- Replace condition check with more easily extensible nonCondition array to check inclusion against.
- Check for unlinked and non-PC tokens as well as actors to prevent condition check failing, which would also prevent Advantage from being cleared.

### Development / Testing Environment
- Foundry VTT: 10.291
- WFRP4e System: 6.2.2
- GM Toolkit:  6.0.1
