### PR TITLE
Suppress advantage gain for first Dual Wielder hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 * *Added* a new context menu option to chat messages to edit flavour text. [#207](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/207)
 * *Added* a quick launch macro to easily access GM Toolkit Settings without having to navigate Foundry configuration menus. [#203](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/203)
 * *Fixed* issue where Add XP macro uses default group setting for Group Tests rather than Session Turnover. [#201](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/201)
+*  * Fixed* issue where a character would gain an advantage boost for their first melee or ranged strike when using the Dual Wielder talent. [#205](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/205)
 
 ## [Version 6.0.1](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/6.0.1) (2022-10-13)
 * *Changed* **minimum compatibility requirements** to Foundry VTT v10.288 and WFRP4e 6.1.4.

--- a/modules/advantage.mjs
+++ b/modules/advantage.mjs
@@ -278,6 +278,7 @@ export default class Advantage {
 Hooks.on("wfrp4e:applyDamage", async function (scriptArgs) {
   GMToolkit.log(false, scriptArgs)
   if (!scriptArgs.opposedTest.defenderTest.context.unopposed) return // Only apply when Outmanouevring (ie, damage from an unopposed test).
+  if (attackerTest.preData.dualWielding) return // Exit if this is the first strike when Dual Wielding
   if (!game.settings.get(GMToolkit.MODULE_ID, "automateDamageAdvantage")) return
   if (!inActiveCombat(scriptArgs.opposedTest.attackerTest.actor)
     | !inActiveCombat(scriptArgs.opposedTest.defenderTest.actor)) return // Exit if either actor is not in the active combat
@@ -379,6 +380,7 @@ Hooks.on("wfrp4e:opposedTestResult", async function (opposedTest, attackerTest, 
 
   // WINNING: Update Advantage for Opposed Tests
   if (defenderTest.context.unopposed) return // Unopposed Test. Advantage from outmanouevring is handled if damage is applied (on wfrp4e:applyDamage hook)
+  if (attackerTest.preData.dualWielding) return // Exit if this is the first strike when Dual Wielding
   if (!game.settings.get(GMToolkit.MODULE_ID, "automateOpposedTestAdvantage")) return
 
   const attacker = attackerTest.actor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run linting on my code to follow the follow the [style](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/blob/dev/.eslintrc.json) of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new unhandled or unexpected warnings.

## Related Issue(s) 
Fixes or addresses #issue(s): #205

## Description

### Motivation and context
Characters usng the Dual Wielder talent gain advantage for a successful first strike. This should only be gained when the second strike has been succesfully resolved.

### Summary of changes
- Added new guards for checking against Winning and Outmanouvring advantage scenarios, as the Dual Wielder talent can be applied to melee and ranged attacks. 
- The WFRP4e system on Foundry does flag the first Dual Wielder attack, but not the second offhand attack. As the second is manually targeted and resolved if the first is successful, this implementation works by ignoring the Dual Wielding strike for advantage purposes, and treating any subsequent as any regular attack. 
- If the second offhand attack is not successful, then both hits will not have been, so no advantage is gained. 
- If it is successful, then advantage is gained as normal
- This is treated the same whether using group or personal advantage.

### Development / Testing Environment
- Foundry VTT: v10.291
- WFRP4e System: 6.22
- GM Toolkit:  dev:1f85c56
