### PR TITLE
Correctly identify non-combatant actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 * *Added* a new context menu option to chat messages to edit flavour text. [#207](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/207)
 * *Added* a quick launch macro to easily access GM Toolkit Settings without having to navigate Foundry configuration menus. [#203](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/203)
 * *Fixed* issue where Add XP macro uses default group setting for Group Tests rather than Session Turnover. [#201](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/201)
-*  * Fixed* issue where a character would gain an advantage boost for their first melee or ranged strike when using the Dual Wielder talent. [#205](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/205)
+*  *Fixed* issue where a character would gain an advantage boost for their first melee or ranged strike when using the Dual Wielder talent. [#205](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/205)
+*  *Fixed* issue where an actor is identified as being in combat even though they are not in the combat tracker, leading to a false notification that an Advantage update is pending for winning an opposed test. [#213](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/213)
 
 ## [Version 6.0.1](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/6.0.1) (2022-10-13)
 * *Changed* **minimum compatibility requirements** to Foundry VTT v10.288 and WFRP4e 6.1.4.

--- a/modules/utility.mjs
+++ b/modules/utility.mjs
@@ -171,16 +171,16 @@ export function getSession () {
  * @returns {boolean}       :
  **/
 export function inActiveCombat (character, notification = true) {
-  let inActiveCombat = game.combats?.active != null
+  let inActiveCombat = false
 
   if (game.combats?.active?.combatants?.contents
-    .filter(a => a.actorId === character.id) === false
+    .filter(a => a.actorId === character.id).length === 0
   ) {
-    inActiveCombat = false
     let message = `${game.i18n.format("GMTOOLKIT.Advantage.NotInCombat", { actorName: character.name, sceneName: game.scenes.viewed.name })}`
     if (notification !== "silent") {
       notification === "persist" ? ui.notifications.error(message, { permanent: true }) : ui.notifications.error(message)
     } else {
+      inActiveCombat = true
       GMToolkit.log(true, message)
     }
   }


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run linting on my code to follow the follow the [style](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/blob/dev/.eslintrc.json) of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new unhandled or unexpected warnings.

## Related Issue(s) 
Fixes or addresses #issue(s): #213

## Description

### Motivation and context
When running an opposed test with a non-combatant, a misleading notification would suggest the winner of the opposed test would gain Advanatge.

### Summary of changes
- Fix the utility function that (a) checks whether an actor's token is in the active combat, and (b) reports if not.

### How has this been tested?
Run opposed test with a non-combatant.

### Development / Testing Environment
- Foundry VTT: 10.291
- WFRP4e System: 6.4.0
- GM Toolkit:  dev:0813736
