### PR TITLE
Fix broken advantage automation

### DIFF
--- a/modules/advantage.mjs
+++ b/modules/advantage.mjs
@@ -278,7 +278,7 @@ export default class Advantage {
 Hooks.on("wfrp4e:applyDamage", async function (scriptArgs) {
   GMToolkit.log(false, scriptArgs)
   if (!scriptArgs.opposedTest.defenderTest.context.unopposed) return // Only apply when Outmanouevring (ie, damage from an unopposed test).
-  if (attackerTest.preData.dualWielding) return // Exit if this is the first strike when Dual Wielding
+  if (scriptArgs.opposedTest.attackerTest.preData.dualWielding) return // Exit if this is the first strike when Dual Wielding
   if (!game.settings.get(GMToolkit.MODULE_ID, "automateDamageAdvantage")) return
   if (!inActiveCombat(scriptArgs.opposedTest.attackerTest.actor)
     | !inActiveCombat(scriptArgs.opposedTest.defenderTest.actor)) return // Exit if either actor is not in the active combat

--- a/modules/utility.mjs
+++ b/modules/utility.mjs
@@ -176,13 +176,15 @@ export function inActiveCombat (character, notification = true) {
   if (game.combats?.active?.combatants?.contents
     .filter(a => a.actorId === character.id).length === 0
   ) {
+    // character is not in combat
     let message = `${game.i18n.format("GMTOOLKIT.Advantage.NotInCombat", { actorName: character.name, sceneName: game.scenes.viewed.name })}`
     if (notification !== "silent") {
       notification === "persist" ? ui.notifications.error(message, { permanent: true }) : ui.notifications.error(message)
-    } else {
-      inActiveCombat = true
-      GMToolkit.log(true, message)
     }
+    GMToolkit.log(true, message)
+  } else {
+    // character is in combat
+    inActiveCombat = true
   }
   return inActiveCombat
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run linting on my code to follow the follow the [style](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/blob/dev/.eslintrc.json) of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new unhandled or unexpected warnings.

## Related Issue(s) 
Fixes or addresses #issue(s): 
- #211 
- #213 

## Description

### Motivation and context
Fixes breaking regressions introduced by 
- fix for dual advantage
- fix for checking whether character is in combat

### Summary of changes
- Fully qualify attackerTest check when applyDamage hook is called
- Resolve logic and parenthetical order in inActiveCombat utility

### Development / Testing Environment
- Foundry VTT: v10.291 
- WFRP4e System: v6.4.0 
- GM Toolkit:  v6.0.2


