### PR TITLE
Add template support for non-integer numeric settings

### DIFF
--- a/modules/gm-toolkit-settings.mjs
+++ b/modules/gm-toolkit-settings.mjs
@@ -215,6 +215,7 @@ export class GMToolkitSettings {
       config: false,
       default: 2,
       type: Number,
+      step: "any",
       feature: "vision"
     })
     game.settings.register(GMToolkit.MODULE_ID, "rangeDarkVision", {
@@ -224,6 +225,7 @@ export class GMToolkitSettings {
       config: false,
       default: 120,
       type: Number,
+      step: "any",
       feature: "vision"
     })
     game.settings.register(GMToolkit.MODULE_ID, "overrideNightVision", {
@@ -348,6 +350,7 @@ export function getDataSettings (data, feature) {
     if (s.type === Number & !s.range) {
       s.isNumber = true
       s.inputType = "number"
+      s.step = s.step ?? 1
     }
     s.value = game.settings.get(s.namespace, s.key)
   })

--- a/templates/gm-toolkit-settings.html
+++ b/templates/gm-toolkit-settings.html
@@ -23,7 +23,7 @@
             <span class="range-value">{{setting.value}}</span>
             
             {{else if setting.isNumber}}
-            <input type="number" name="{{setting.key}}" data-dtype="Number" value="{{setting.value}}"/>
+            <input type="number" name="{{setting.key}}" data-dtype="Number" value="{{setting.value}}" step="{{setting.step}}"/>
     
             {{else if setting.filePicker}}
             {{filePicker target=setting.key type=setting.filePickerType}}


### PR DESCRIPTION
## Type of change
- [x] Enhancement (non-breaking change which improves functionality)

## Related Issue(s) 
Fixes or addresses #issue(s):  #223

## Description

### Motivation and context
Foundry validation of number input fields defaults validation to nearest 1. This works reasonably well for integer fields, but prevents fractions, such as for vision ranges. 

### Summary of changes
- Add `step: any` key:value to selected Number-based settings (specifically, default ranges for normal and dark vision)
- Adds template support for settings form app to handle variable steps for number inputs
- Defaults step to 1 if not specified for number based settings (to mimic previous defulat behaviour) 

### Development / Testing Environment
- Foundry VTT: v10.291
- WFRP4e System: v6.5.3
- GM Toolkit:  v6.0.3