### PR TITLE
Refactor Group Test actor test functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.  The format
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 * *Added* support for setting non-integer default ranges for normal and dark vision. [#223](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/223) 
-* *Changed* Group Test actor test functions to avoid deprecated system test functions.
+* *Changed* Group Test actor test functions to avoid deprecated system test functions. [#226](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/226)
 
 ## [Version 6.0.3](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/6.0.3)  (2023-04-25)
 * *Fixed* issue where Advantage was not applied on opposed or unopposed tests. [#217](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/217)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.  The format
 
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
-* *Added* support for setting non-integer default ranges for normal and dark vision. [[#223](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/223) 
+* *Added* support for setting non-integer default ranges for normal and dark vision. [#223](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/223) 
+* *Changed* Group Test actor test functions to avoid deprecated system test functions.
 
 ## [Version 6.0.3](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/6.0.3)  (2023-04-25)
 * *Fixed* issue where Advantage was not applied on opposed or unopposed tests. [#217](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/217)


### PR DESCRIPTION
## Type of change
- [x] Refactor 

## Description

### Motivation and context
Removes use of deprecated functions when running actor tests for Make (Secret) Group Test macro

### Summary of changes
- Remove extra call for basicTest
- Establish reusable setupData parameter

### Development / Testing Environment
- Foundry VTT: v10.291
- WFRP4e System: 6.5.3
- GM Toolkit:  v6.0.3

