### PR TITLE
Add WFRP4e v7.x install compatibillty #241

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.  The format
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 
+## [Version 6.0.5](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/6.0.5)  (2023-09-03)
+* *Added* compatibility for FVTT v11. [#241](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/241)
+* *Updated* word-wrap dependency version. [#238](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/238)
+
 ## [Version 6.0.4](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/6.0.4)  (2023-06-04)
 * *Added* compatibility for FVTT v11. [#228](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/228)
 * *Changed* **minimum compatibility requirements** to Foundry VTT v10.291 and WFRP4e 6.5.7.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "wfrp4e-gm-toolkit",
     "title": "GM Toolkit (WFRP4e)",
     "description": "Utilities for WFRP4e GMs",
-    "version": "6.0.4",
+    "version": "6.0.5",
     "compatibility": {
         "minimum": "10.291",
         "verified": "11.300",
@@ -22,8 +22,7 @@
                 "type": "system",
                 "compatibility": {
                     "minimum": "6.5.7",
-                    "verified": "6.5.7",
-                    "maximum": "6.x"
+                    "verified": "6.5.7"
                 }
             }
         ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Release (administrative update for tagged release, eg, changelog, readme, manifest)
- [x] Maintenance (updates to the repository, dependencies and other non-functional code management)

## Related Issue(s) 
Fixes or addresses #issue(s): #241

## Description

### Motivation and context / Summary of changes
Adds install compatibility for WFRP4e v7 by removing max system compatibility flag in the manifest

### Development / Testing Environment
- Foundry VTT: 10.303 and  11.308
- WFRP4e System: v6.6.1 and v7.0.1

