### PR TITLE
Advantage automation: ignore new conditions outside of combat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 * *Changed* compendium packs from `nedb` to `leveldb` format.  This database format is used from Foundry v11, and this change breaks GM Toolkit compatibility with earlier versions of Foundry. [#247](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/247)
 * *Updated* package dependencies and linting rules. [#248](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/248)
 * *Updated* Japanese translations (thanks @doumoku!) [#245](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/245)
+* *Fixed* incorrect notification of Advantage change when condition is applied outside of combat. [[#249](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/249)]
 
 ## [Version 6.0.5](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/6.0.5)  (2023-09-03)
 * *Added* compatibility for FVTT v11. [#241](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/241)

--- a/modules/advantage.mjs
+++ b/modules/advantage.mjs
@@ -448,7 +448,8 @@ Hooks.on("createActiveEffect", async function (conditionEffect) {
   if (!game.settings.get(GMToolkit.MODULE_ID, "automateConditionAdvantage")) return // ... not using condition automation
   if (game.settings.get("wfrp4e", "useGroupAdvantage")) return // ... Group Advantage is in play
   if (!game.user.isUniqueGM) return // ... not a GM
-  if (!inActiveCombat(conditionEffect.parent, "silent")) return // ... not in combat
+  // if (!inActiveCombat(conditionEffect.parent, "silent")) return // ... not in combat
+  if (!conditionEffect.parent.inCombat) return // ... not in combat
   if (!conditionEffect.isCondition) return  // ... not a system recognised condition
   const nonConditions = ["dead", "fear", "grappling", "engaged"]
   const condId = conditionEffect.conditionId


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue(s) 
Fixes or addresses #issue(s): #249

## Description

### Motivation and context
When a condition is added outside of combat, there should be no effect on advantage. 

### Summary of changes
Correctly check that a token is in combat before attempting and notifying of a change to Advantage.

### Development / Testing Environment
- Foundry VTT: 11.315
- WFRP4e System: 7.0.3
- GM Toolkit:  6.0.5
