### PR TITLE
Enable support for player delegated group test results

### DIFF
--- a/modules/socket.mjs
+++ b/modules/socket.mjs
@@ -2,33 +2,44 @@ import GMToolkit from "./gm-toolkit.mjs"
 
 export default class SocketHandlers {
 
-  // Used for updating Advantage when the opposed test is resolved by a player character that does not own the opposing character
-  static async updateAdvantage (data, options, response) {
-    GMToolkit.log(true, "Socket: updateAdvantage. Payload.", data)
-    // console.log("Socket: updateAdvantage", options)
-    // console.log("Socket: updateAdvantage", response)
+  /**
+   * Update combatant Advantage when the opposed test is resolved
+   * by a player character that does not own the opposing character
+   * @param {Object} data :
+   *  type (indicating socket context)
+   *  payload (with transaction specific data)
+   * @param {string} options : id of requesting user
+   * -------------------------------------------- **/
+  static async updateAdvantage (data, options) {
+    GMToolkit.log(true, `Socket: ${data.type}. Payload.`, data, options)
 
     if (!game.user.isUniqueGM) return
 
     const character = game.scenes.active.tokens
       .filter(t => t.actor.id === data.payload.character)[0].actor
-    GMToolkit.log(true, "Socket: updateAdvantage. Character.", character)
+    GMToolkit.log(true, `Socket: ${data.type}. Character.`, character)
 
     const updated = await character.update(data.payload.updateData)
-    GMToolkit.log(true, "Socket: updateAdvantage. Updated.", updated)
+    GMToolkit.log(true, `Socket: ${data.type}. Updated.`, updated)
     return updated
   }
 
-  // Used for updating Advantage flags on combatant when the opposed test is resolved by a player character that does not own the opposing actor
-  static async setFlag (data, options, response) {
-    GMToolkit.log(true, "Socket: setFlag. Payload.", data)
-    // console.log("Socket: setFlag", options)
-    // console.log("Socket: setFlag", response)
+
+  /**
+   * Update combatant Advantage flags when the opposed test is resolved
+   * by a player character that does not own the opposing character
+   * @param {Object} data :
+   *  type (indicating socket context)
+   *  payload (with transaction specific data)
+   * @param {string} options : id of requesting user
+   * -------------------------------------------- **/
+  static async setFlag (data, options) {
+    GMToolkit.log(true, `Socket: ${data.type}. Payload.`, data, options)
 
     if (!game.user.isUniqueGM) return
 
     const combatant = game.combat.combatants.get(data.payload.character._id)
-    GMToolkit.log(true, "Socket: setFlag. Combatant.", combatant)
+    GMToolkit.log(true, `Socket: ${data.type}. Combatant.`, combatant)
 
     ui.notifications.notify(`Setting flag \`${data.payload.updateData.key}\` to \`${data.payload.updateData.value}\` on ${combatant.token.name} as GM`,
       "info",
@@ -40,7 +51,7 @@ export default class SocketHandlers {
       data.payload.updateData.flag,
       { [data.payload.updateData.key]: data.payload.updateData.value }
     )
-    GMToolkit.log(true, "Socket: setFlag. Updated.", updated)
+    GMToolkit.log(true, `Socket: ${data.type}. Updated.`, updated)
     return updated
   }
 

--- a/wfrp4e-gm-toolkit.mjs
+++ b/wfrp4e-gm-toolkit.mjs
@@ -99,8 +99,8 @@ Hooks.once("ready", async function () {
   })
 
   // Register socket handler
-  game.socket.on(`module.${GMToolkit.MODULE_ID}`, (data, options, response) => {
-    SocketHandlers[data.type](data, options = {}, response)
+  game.socket.on(`module.${GMToolkit.MODULE_ID}`, (data, options) => {
+    SocketHandlers[data.type](data, options)
   })
 
   GMToolkitWelcome._welcomeMessage()


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Description

### Motivation and context
Make socket handling a bit more consistent and get ready for supporting player delegated rolls using existing Make Secret Group Test framework

### Summary of changes
- Add descriptors to socket methods
- Extend socket handling for deletated group tests
- Standardise logging for socket calls

### Development / Testing Environment
- Foundry VTT: 11.315
- WFRP4e System: 7.0.3
- GM Toolkit:  6.0.5
