### PR TITLE
Fix group advantage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/*
 .vscode/*
 packs/*/*
 .fvttrc.yml
+.idea/

--- a/modules/advantage.mjs
+++ b/modules/advantage.mjs
@@ -108,7 +108,7 @@ export default class Advantage {
     async function updateCharacterAdvantage () {
       let updated = ""
 
-      if (!character.actor.ownership[game.user.id]) {
+      if (!character.actor.isOwner) {
         return updated = await game.socket.emit(
           `module.${GMToolkit.MODULE_ID}`,
           {
@@ -316,7 +316,7 @@ Hooks.on("wfrp4e:applyDamage", async function (scriptArgs) {
   if (character.combatant.getFlag(GMToolkit.MODULE_ID, "advantage")?.outmanoeuvre !== scriptArgs.opposedTest.attackerTest.message.id) {
     await Advantage.update(character, "increase", "wfrp4e:applyDamage")
 
-    if (!character.actor.ownership[game.user.id]) {
+    if (!character.actor.isOwner) {
       await game.socket.emit(`module.${GMToolkit.MODULE_ID}`, {
         type: "setFlag",
         payload: {
@@ -347,7 +347,7 @@ Hooks.on("wfrp4e:opposedTestResult", async function (opposedTest, attackerTest, 
   if (!game.settings.get("wfrp4e", "useGroupAdvantage")) {
     // Flag attacker charging
     if (attackerTest.data.preData?.charging || attackerTest.data.result.other === game.i18n.localize("Charging")) {
-      if (!attackerTest.actor.ownership[game.user.id]) {
+      if (!attackerTest.actor.isOwner) {
         await game.socket.emit(`module.${GMToolkit.MODULE_ID}`, {
           type: "setFlag",
           payload: {
@@ -368,7 +368,7 @@ Hooks.on("wfrp4e:opposedTestResult", async function (opposedTest, attackerTest, 
     }
     // Flag defender charging
     if (defenderTest.data.preData?.charging || defenderTest.data.result.other === game.i18n.localize("Charging")) {
-      if (!defenderTest.actor.ownership[game.user.id]) {
+      if (!defenderTest.actor.isOwner) {
         await game.socket.emit(`module.${GMToolkit.MODULE_ID}`, {
           type: "setFlag",
           payload: {
@@ -425,7 +425,7 @@ Hooks.on("wfrp4e:opposedTestResult", async function (opposedTest, attackerTest, 
       GMToolkit.log(true, "No advantage gained for winning an opposed test you did not initiate.")
     } else {
       const resolution = await Advantage.update(character, "increase", "wfrp4e:opposedTestResult")
-      if (!winner.ownership[game.user.id]) {
+      if (!winner.isOwner) {
         await game.socket.emit(`module.${GMToolkit.MODULE_ID}`, {
           type: "setFlag",
           payload: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 
## Type of change
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in the box that applies.  Delete any option that is not applicable. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation (updates existing localization strings or adds complete new language file)
- [ ] Release (administrative update for tagged release, eg, changelog, readme, manifest)
- [ ] Maintenance (updates to the repository, dependencies and other non-functional code management)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run linting on my code to follow the follow the [style](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/blob/dev/.eslintrc.json) of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new unhandled or unexpected warnings.
- [ ] My change requires an update to the [documentation](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/wiki).
- [x] I can be reached on Discord by my handle: `forien`

## Related Issue(s) 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
  - Fixes #237 
  - Fixes #250 

## Description

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
Checking `Document.ownership[game.user.id]` is unsafe, as it may (and will) return `undefined` for GM, if GM is not **explicit** Owner of a Document.

#### For example:
There are 2 users in the world:
1. GM with `aDepqlKkeOa13DWo` id
2. User with `JYO5JplQ4zaynRJ4` id

There is an Actor with the following `ownership` structure:
```js
ownership = {
    "default": 1,
    "JYO5JplQ4zaynRJ4": 3
}
```

Current way of checking ownership would return `undefined` for GM, even though **GM is always an implicit Owner of any and every Document**.

Which is why using `Document.isOwner` getter is superior, and in my opinion, the only proper way of checking the ownership for _current_ user.

#### Why didn't it work?

Actors created by **Players** (for example using **Chargen** if they have permission) do not have GM as an explicit Owner. Similarly, Actors that can be created programatically may not have GM as explicit Owner neither. 


### Summary of changes
<!-- Please include a summary of what behaviour/functionality has changed, been introduced or removed. -->
<!-- List any dependencies that are required for this change. --> 
Replaced every occurrence of `.ownership[game.user.id]` with `.isOwner`

### How has this been tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of tests you ran to see how your change affects existing code. -->
Ran Opposed Tests, using "Group Advantage" ruleset with Actors created by User as Attackers. 

### Development / Testing Environment
- Foundry VTT: 11.315<!-- eg, v10.278 --> 
- WFRP4e System: 7.1.4<!-- eg, v6.0.0 -->
- GM Toolkit: 7.0.0<!-- eg, v0.9.5, dev:6a93add -->


_Btw, I spend more time filing this form than making PR lol 😂_
