### PR TITLE
Allow a flag in Test `options` that would disable automatic advantage gain

### DIFF
--- a/modules/advantage.mjs
+++ b/modules/advantage.mjs
@@ -343,6 +343,15 @@ Hooks.on("wfrp4e:applyDamage", async function (scriptArgs) {
 Hooks.on("wfrp4e:opposedTestResult", async function (opposedTest, attackerTest, defenderTest) {
   GMToolkit.log(true, "wfrp4e:opposedTestResult", opposedTest, attackerTest, defenderTest)
 
+  // For Group Advantage, handle tests which should not generate advantage
+  if (
+    game.settings.get("wfrp4e", "useGroupAdvantage") &&
+    attackerTest.data?.result?.options?.preventAdvantage === true
+  ) {
+    GMToolkit.log(true, "No advantage gained for winning an opposed test that should not generate advantage.");
+    return;
+  }
+
   // CHARGING: Set Advantage flag if attacker and/or defender charged, and Group Advantage is not being used. Do this once before exiting for unopposed tests.
   if (!game.settings.get("wfrp4e", "useGroupAdvantage")) {
     // Flag attacker charging


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 
## Type of change
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in the box that applies.  Delete any option that is not applicable. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation (updates existing localization strings or adds complete new language file)
- [ ] Release (administrative update for tagged release, eg, changelog, readme, manifest)
- [ ] Maintenance (updates to the repository, dependencies and other non-functional code management)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run linting on my code to follow the follow the [style](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/blob/dev/.eslintrc.json) of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new unhandled or unexpected warnings.
- [x] My change requires an update to the [documentation](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/wiki).
- [x] I can be reached on Discord by my handle: `forien`

## Description

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
Some Opposed Tests (namely, Group Advantage actions) should not generate advantage when winning them. And while system itself does not handle that in any way, I've added support for that in the new Token Action HUD WFRP4e update, as can be seen here (for example): 

https://github.com/Foundry-Workshop/token-action-hud-wfrp4e/blob/1356baa3439c4b6b6f450399d9c288bd86efa2af/dist/modules/GroupAdvantage.js#L76-L84

I went ahead and added a new flag in Tests' options called `preventAdvantage` with the idea that if the `attackerTest` has that flag, then no advantage should be generated by that test by other automations. 

### Summary of changes
<!-- Please include a summary of what behaviour/functionality has changed, been introduced or removed. -->
<!-- List any dependencies that are required for this change. --> 
Added a check that checks for two things:
1. Is the Group Advantage enabled?
2. Does the `attackerTest` have option `preventAdvantage` set **exactly** to `true`?

If both are true, then advantage is not calculated for the Opposed Test. 

### How has this been tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of tests you ran to see how your change affects existing code. -->

1. Use Group Advantage actions like `Batter`, `Trick` or `Additional Effort` from the Token Action HUD WFRP4e v1.2.0
  - should notice that they no longer grant advantage due to "won opposed test", but instead grant advantage based on actions themselves
3. Perform any Opposed Test outside of actions mentioned above
  - should notice that automated advantage is handled as usual by GM Toolkit

### Development / Testing Environment
- Foundry VTT: 11.315
- WFRP4e System: 7.2.0
- GM Toolkit:  current forked branch, including https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/commit/121bc229b659c089008cc88c9dbaaf15e2f7829c
