### PR TITLE
Add pack compiler to release workflow #265

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      # Get Foundry CLI
+      - name: Install FVTT CLI
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      # Compile compendium packs
+      - run: npm i -g @foundryvtt/foundryvtt-cli
+      - run: python pack_util.py pack
       
       # Get Module ID
       - name: Get Module ID
@@ -39,8 +49,8 @@ jobs:
         with:
           allowUpdates: true # Set this to false if you want to prevent updating existing releases
           name: ${{ github.event.release.name }}
-          draft: ${{ github.event.release.unpublished }}
-          prerelease: ${{ github.event.release.prerelease }}
+          # draft: ${{ github.event.release.unpublished }}
+          # prerelease: ${{ github.event.release.prerelease }}
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: "./module.json, ./${{steps.moduleID.outputs.prop}}.zip"
           tag: ${{ github.event.release.tag_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.  The format
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 
+## [Version 7.0.1](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/7.0.1)  (2024-06-11)
+* *Added* pack compiler to release workflow to ensure compendium packs are included in module package. [[#265](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/265)]
+
 ## [Version 7.0.0](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/7.0.0)  (2024-06-11)
 * *Changed* compendium packs from `nedb` to `leveldb` format.  This database format is used from Foundry v11, and this change breaks GM Toolkit compatibility with earlier versions of Foundry. [#247](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/247)
 * Fix Group Test to work with roll dialog changes from WFRP4e 7.1.5.


### PR DESCRIPTION
## Type of change
- [x] Maintenance (updates to the repository, dependencies and other non-functional code management)

## Related Issue(s) 
Fixes or addresses #issue(s): #265

## Description

### Motivation and context
Compendium packs are not inculded in module package.

### Summary of changes
Updates github actions release workflow to include compiled packs
