### PR TITLE
Fix end of round operations happening every combat turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
+* *Fixed* end of round operations happening at the end every combat turn. Lose Momentum is no longer triggered after each character turn. [[#275](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/275)]
 
 ## [Version 7.1.1](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/v7.1.1)  (2024-08-12)
 * *Fixed* Maintenance utility not loading when (RollTable) content version flag is missing


### PR DESCRIPTION
[275-lose-momentum.webm](https://github.com/user-attachments/assets/57ec69a5-dd28-42f7-8cdb-d575002b8de3)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue(s) 
Fixes or addresses #issue(s):  #275

## Description

### Motivation and context
Prevents Lose Momentum from being triggered after each character turn when using non-Group Advantage.  

### Summary of changes
<!-- Please include a summary of what behaviour/functionality has changed, been introduced or removed. -->
<!-- List any dependencies that are required for this change. --> 
- simplified how end of round is determined when checking for preUpdateCombat routines
- refactored the Lose Momentum dialog to reduce the number of parameters passed

### Development / Testing Environment
- Foundry VTT: 12.331
- WFRP4e System: 7.2.4
- GM Toolkit:  7.1.1

