### PR TITLE
Add setting to override status effect hud background colour #240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.  The format
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 
+- *Added* setting to choose background colour of status effects (conditions) in token hud. [#240](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/240)
+  - Leave blank for system default.
+  - GM Toolkit default is #cececeff.
+
 ## [Version 8.0.1](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/v8.0.1)  (2024-09-21)
 - *Added* WFRP4e v8 compatibility for Check Conditions macro.
 - *Added* Japanese translation updates. Thanks @doumoku! [[#281](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/281)]

--- a/css/gmtoolkit.css
+++ b/css/gmtoolkit.css
@@ -108,15 +108,13 @@
 /* 1d. Override Status Effects to avoid overlap */
 
 #token-hud .status-effects {
-    /* top: -36px;  /* Realign to avoid placement conflict wth combat hud extensions */
 	bottom: unset;
-	background: #ececec; /* Change background to improve status effect visibility */
 	width: 144px; /* Accommodate larger (wider) effect controls */
 }
 
 #token-hud .status-effects .effect-control {
-    width: 36px;  /* Accommodate larger effect controls */
-    height: 36px;  /* Accommodate larger (wider) effect controls */
+  width: 36px;  /* Accommodate larger effect controls */
+  height: 36px;  /* Accommodate larger (wider) effect controls */
 	opacity: 0.75;  /* Improve visual clarity */
 }
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -29,6 +29,8 @@
     "GMTOOLKIT.Settings.TokenHudExtensions.Enabled.hint" : "Tooltips und Interaktionen für Schlüsselattribute und -fertigkeiten sind über das Hud der kontrollierten Token verfügbar. Standardmäßig aktiviert.",
     "GMTOOLKIT.Settings.TokenHudExtensions.AlwaysShowInitiative.name" : "Initiative immer in Token Hud Extension anzeigen",
     "GMTOOLKIT.Settings.TokenHudExtensions.AlwaysShowInitiative.hint" : "Wenn diese Option deaktiviert ist, sind die Tooltips und Shortcuts für Initiative und Gewandtheit nur in aktiven Szenen verfügbar. Standardmäßig aktiviert.",
+    "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.name" : "Override Status Effects HUD Background Colour",
+    "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.hint" : "Leave blank for system default. GM Toolkit default is #CECECEFF. Specify alternatives in any of the following formats, without quotes: '#000000aa', 'rgba(0,0,0,0.6)', 'yellow'.",
     "GMTOOLKIT.TokenHudExtension.StatusChanged" : "{targetStatus} geändert von {originalStatus} auf {newStatus} für {targetName}",
     "GMTOOLKIT.TokenHudExtension.StatusNotChanged" : "{targetStatus} ist unverändert bei {originalStatus} für {targetName}",
     "GMTOOLKIT.TokenHudExtension.LittlePrayerResult" : "<p>{actorName} hat ein kleines Gebet zu den Göttern gesprochen ({littlePrayerResult}).</p>",

--- a/lang/en.json
+++ b/lang/en.json
@@ -29,6 +29,8 @@
     "GMTOOLKIT.Settings.TokenHudExtensions.Enabled.hint" : "Make tooltips and interactions for key attributes and skills available from the hud of controlled tokens. Enabled by default.",
     "GMTOOLKIT.Settings.TokenHudExtensions.AlwaysShowInitiative.name" : "Always Show Initiative in Token Hud Extension",
     "GMTOOLKIT.Settings.TokenHudExtensions.AlwaysShowInitiative.hint" : "If disabled, Initiative and Agility tooltips and shortcuts are only available in active scenes. Enabled by default.",
+    "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.name" : "Override Status Effects HUD Background Colour",
+    "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.hint" : "Leave blank for system default. GM Toolkit default is #CECECEFF. Specify alternatives in any of the following formats, without quotes: '#000000aa', 'rgba(0,0,0,0.6)', 'yellow'.",
     "GMTOOLKIT.TokenHudExtension.StatusChanged" : "{targetStatus} changed from {originalStatus} to {newStatus} for {targetName}",
     "GMTOOLKIT.TokenHudExtension.StatusNotChanged" : "{targetStatus} is unchanged at {originalStatus} for {targetName}",
     "GMTOOLKIT.TokenHudExtension.LittlePrayerResult" : "<p>{actorName} offered a Little Prayer to the Gods ({littlePrayerResult}).</p>",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -29,6 +29,8 @@
     "GMTOOLKIT.Settings.TokenHudExtensions.Enabled.hint" : "Crée des info-bulles et des interactions pour les attributs et les Compétences clés disponibles grâce à l'ATH des Pions contrôlés. Activé par défaut.",
     "GMTOOLKIT.Settings.TokenHudExtensions.AlwaysShowInitiative.name" : "Toujours montrer l'Initiative dans l'Extension de l'ATH de Pion",
     "GMTOOLKIT.Settings.TokenHudExtensions.AlwaysShowInitiative.hint" : "En cas de désactivation, les info-bulles et les raccourcis de l'Initiative et de l'Agilité seront uniquement disponibles dans les Scènes actives. Activé par défaut.",
+    "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.name" : "Override Status Effects HUD Background Colour",
+    "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.hint" : "Leave blank for system default. GM Toolkit default is #CECECEFF. Specify alternatives in any of the following formats, without quotes: '#000000aa', 'rgba(0,0,0,0.6)', 'yellow'.",
     "GMTOOLKIT.TokenHudExtension.StatusChanged" : "{targetStatus} est passé de {originalStatus} à {newStatus} pour {targetName}",
     "GMTOOLKIT.TokenHudExtension.StatusNotChanged" : "{targetStatus} demeure à {originalStatus} pourr {targetName}",
     "GMTOOLKIT.TokenHudExtension.LittlePrayerResult" : "<p>{actorName} a offert une Modeste Prière aux Dieux ({littlePrayerResult}).</p>",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -29,6 +29,8 @@
     "GMTOOLKIT.Settings.TokenHudExtensions.Enabled.hint" : "操作中のコマHUDに、主要な能力値や技能のツールチップとインタラクションを追加します。既定値は「許可」です。",
     "GMTOOLKIT.Settings.TokenHudExtensions.AlwaysShowInitiative.name" : "コマのHUD拡張で、常に【機転】を表示",
     "GMTOOLKIT.Settings.TokenHudExtensions.AlwaysShowInitiative.hint" : "無効にすると、【機転】と【敏捷】のツールチップとショートカットは有効なシーンでのみ使用できるようになります。既定値は「有効」です。",
+    "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.name" : "Override Status Effects HUD Background Colour",
+    "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.hint" : "Leave blank for system default. GM Toolkit default is #CECECEFF. Specify alternatives in any of the following formats, without quotes: '#000000aa', 'rgba(0,0,0,0.6)', 'yellow'.",
     "GMTOOLKIT.TokenHudExtension.StatusChanged" : "{targetName}の{targetStatus}が、{originalStatus}から{newStatus}に変更された",
     "GMTOOLKIT.TokenHudExtension.StatusNotChanged" : "{targetName}の{targetStatus}は{originalStatus}で、変更されなかった",
     "GMTOOLKIT.TokenHudExtension.LittlePrayerResult" : "<p>{actorName}は神々に「小さな願い」を捧げた（{littlePrayerResult}）。</p>",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -29,6 +29,8 @@
     "GMTOOLKIT.Settings.TokenHudExtensions.Enabled.hint": "Udostępniaj podpowiedzi i interakcje dotyczące kluczowych atrybutów i umiejętności z poziomu kontrolowanych tokenów. Domyślnie włączone.",
     "GMTOOLKIT.Settings.TokenHudExtensions.AlwaysShowInitiative.name": "Zawsze pokazuj Inicjatywę przy rozszerzeniu ekranu tokenów",
     "GMTOOLKIT.Settings.TokenHudExtensions.AlwaysShowInitiative.hint": "Po wyłączeniu podpowiedzi i skróty Inicjatywy i Zwinności są dostępne tylko w aktywnych scenach. Domyślnie włączone.",
+    "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.name" : "Override Status Effects HUD Background Colour",
+    "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.hint" : "Leave blank for system default. GM Toolkit default is #CECECEFF. Specify alternatives in any of the following formats, without quotes: '#000000aa', 'rgba(0,0,0,0.6)', 'yellow'.",
     "GMTOOLKIT.TokenHudExtension.StatusChanged": "{targetStatus} zmieniono z {originalStatus} na {newStatus} dla {targetName}",
     "GMTOOLKIT.TokenHudExtension.StatusNotChanged": "{targetStatus} pozostaje niezmieniony w {originalStatus} dla {targetName}",
     "GMTOOLKIT.TokenHudExtension.LittlePrayerResult": "<p>{actorName} ofiarował małą modlitwę bogom ({littlePrayerResult}).</p>",

--- a/modules/gm-toolkit-settings.mjs
+++ b/modules/gm-toolkit-settings.mjs
@@ -305,6 +305,17 @@ export class GMToolkitSettings {
       feature: "tokenhud"
     })
 
+    // Settings for Token Hud Extension
+    game.settings.register(GMToolkit.MODULE_ID, "tokenHudStatusEffectsBackground", {
+      name: "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.name",
+      hint: "GMTOOLKIT.Settings.TokenHudExtensions.StatusEffectsBackground.hint",
+      scope: "client",
+      config: true,
+      default: "#cececeff",
+      type: String,
+      feature: "tokenhud"
+    })
+
     // Settings for suppressing Spectator notification
     game.settings.register(GMToolkit.MODULE_ID, "suppressSpectatorNotice", {
       name: "GMTOOLKIT.Settings.Spectators.name",

--- a/wfrp4e-gm-toolkit.mjs
+++ b/wfrp4e-gm-toolkit.mjs
@@ -129,6 +129,7 @@ Hooks.on("preUpdateToken", (token, change) => {
 // Display Token Hud Extension if enabled
 Hooks.on("renderTokenHUD", (app, html, data) => {
   if (game.settings.get(GMToolkit.MODULE_ID, "enableTokenHudExtensions")) TokenHudExtension.addTokenHudExtensions(app, html, data)
+  document.getElementsByClassName("status-effects")[0].style = `background: ${game.settings.get("wfrp4e-gm-toolkit", "tokenHudStatusEffectsBackground")}`
 })
 
 // If Babele is installed, wait until it completed initialisation and then compile localized skills list used for Group Tests


### PR DESCRIPTION
## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Adds new translation keys

## Related Issue(s) 
Fixes or addresses #issue(s): #240

## Description

### Motivation and context
GM Toolkit overrides the status effect hud background colour to improve icon visibility. This causes accessibility issues for some users. 

### Summary of changes
- Add per-client setting to unset or override the hud background colour and transparency
- Remove redundany CSS styling

### Development / Testing Environment
- Foundry VTT: v12.331
- WFRP4e System: v8.0.4
- GM Toolkit:  v8.0.1

### Screen Capture
![image](https://github.com/user-attachments/assets/225a588a-4669-4cd3-b7ec-e3ec64ac733d)
![image](https://github.com/user-attachments/assets/eaa244ca-aa9f-4a91-b274-d0ddb80bd7ce)
![image](https://github.com/user-attachments/assets/cfda9a3d-aa8c-41d0-b48d-078065ad5dc5)

