### PR TITLE
Gain Dual Wielder advantage only when both hits are successful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.  The format
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 
+- *Fixed* advantage automation when using Dual Wielder to only increase when both hits are successful. [#338](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/338)
+
 ## [Version 9.1.0](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/v9.1.0)  (2025-05-27)
 - *Changed* Group Test and Check Conditions functionality to bypass roll dialogs, in line with updated Warhammer Library 2.0.5 implementation. 
   - This raises minimum system compatibility to WFRP4e 9.1.0.

--- a/modules/advantage.mjs
+++ b/modules/advantage.mjs
@@ -406,7 +406,7 @@ Hooks.on("wfrp4e:opposedTestResult", async function (opposedTest, attackerTest, 
 
   // WINNING: Update Advantage for Opposed Tests
   if (defenderTest.context.unopposed) return // Unopposed Test. Advantage from outmanouevring is handled if damage is applied (on wfrp4e:applyDamage hook)
-  if (attackerTest.preData.dualWielding) return // Exit if this is the first strike when Dual Wielding
+  if (attackerTest.data.result.canDualWield) return // Exit if this is the first strike when Dual Wielding
   if (!game.settings.get(GMToolkit.MODULE_ID, "automateOpposedTestAdvantage")) return
 
   const attacker = attackerTest.actor


### PR DESCRIPTION

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue(s) 
Fixes or addresses #issue(s): #338

## Description

### Motivation and context
- `attackerTest.preData.dualWielding` now always seems to be false since the [Dual Wielder refactor](attackerTest.preData.dualWielding).  

### Summary of changes
- Changed the advantage check to use `attackerTest.data.result.canDualWield` instead.  
- If all the [Dual Wielder conditions](https://moo-man.github.io/WFRP4e-FoundryVTT/pages/basics/combat.html#dual-wielder) are met (including setting the secondary weapon as offhand), then it is assumed the user is attempting a Dual Wielder strike.
- If they do not use the Dual Wielder chat button, then they will not gain any advantage automatically for the successful first strike.  
![image](https://github.com/user-attachments/assets/df3a5b7b-57af-426a-9dbd-b1cfc1af4e8e)


### Development / Testing Environment
- Foundry VTT: 13.345
- WFRP4e System: 9.1.1
- GM Toolkit:  9.1.0+

