### PR TITLE
Update selected combatant when Group Advantage has been changed at end of round

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.  The format
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 
 - *Fixed* advantage automation when using Dual Wielder to only increase when both hits are successful. [#338](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/338)
+- *Fixed* issue with combatant not changing at round change when advantage has been automatically applied and when using Group Advantage. [#334](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/issues/334)
 
 ## [Version 9.1.0](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/v9.1.0)  (2025-05-27)
 - *Changed* Group Test and Check Conditions functionality to bypass roll dialogs, in line with updated Warhammer Library 2.0.5 implementation. 

--- a/modules/advantage.mjs
+++ b/modules/advantage.mjs
@@ -531,17 +531,18 @@ Hooks.on("preUpdateCombat", async function (combat, change) {
     Advantage.loseMomentum(combat)
   }
 
-  // Clear Advantage flags when the combat round changes
-  // Still required when Group Advantage is used because of Opposed Test flags
-  GMToolkit.log(true, "preUpdateCombat: unsetting Advantage flags")
-  const advFlagged = combat.combatants.filter(c => c.getFlag("wfrp4e-gm-toolkit", "advantage"))
-  if (advFlagged.length) await Advantage.unsetFlags(advFlagged)
 })
 
 
 Hooks.on("updateCombat", async function (combat, change) {
   if (!combat.round || !game.user.isUniqueGM || !combat.combatants.size) return
   if (!change.round) return // Exit if this isn't the start of a round
+
+  // Clear Advantage flags when the combat round changes
+  // Still required when Group Advantage is used because of Opposed Test flags
+  GMToolkit.log(true, "updateCombat: unsetting Advantage flags")
+  const advFlagged = combat.combatants.filter(c => c.getFlag("wfrp4e-gm-toolkit", "advantage"))
+  if (advFlagged.length) await Advantage.unsetFlags(advFlagged)
 
   GMToolkit.log(false, "updateCombat: Setting startOfRound flag")
   // Skip individual start of round Advantage tracking if Group Advantage is being used


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue(s) 
Fixes or addresses #issue(s): #334

## Description
### Summary of changes
This only affects Group Advantage. The issue occurs when during preUpdate when resetting advantage automation flags (when they have been set that round). Moving the operation from `preUpdateCombat` to `updateCombat` resolves the issue. 

### Development / Testing Environment
- Foundry VTT: 13.345
- WFRP4e System: 9.1.1
- GM Toolkit:  9.1.0+

