### PR TITLE
Fix renderTemplate deprecation warning when calling Advantage Momentum dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.  The format
 
 ## Unreleased
 See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
+- *Fixed* renderTemplate deprecation warning when calling Advantage Momentum dialog.
 
 
 ## [Version 9.2.0](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/v9.2.0)  (2026-05-24)

--- a/modules/advantage.mjs
+++ b/modules/advantage.mjs
@@ -249,7 +249,7 @@ export default class Advantage {
       notgained: checkNotGained,
       none: noAdvantage
     }
-    const dialogContent = await renderTemplate("modules/wfrp4e-gm-toolkit/templates/gm-toolkit-advantage-momentum.html", templateData)
+    const dialogContent = await foundry.applications.handlebars.renderTemplate("modules/wfrp4e-gm-toolkit/templates/gm-toolkit-advantage-momentum.html", templateData)
     let lostAdvantage = ""
 
     foundry.applications.api.DialogV2.wait({


### PR DESCRIPTION
## Type of change
- [x] Deprecation fix (non-breaking change which fixes an issue)

### Development / Testing Environment
- Foundry VTT: 13.346 | 14.363
- WFRP4e System: 9.1.4 |  9.6.1
- GM Toolkit:  9.2.0