### PR TITLE
Fix ContextMenuEntry#callback deprecation warning when calling Edit Message Flavour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 - *Changed* Toggle Scene Vision and Light macro to use scene environment data model `environment.globalLight.enabled`. [#357](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/357)
 - *Changed* Dark Whispers to use dataset actions for chat message intereactions rather than button attributes.  [#358](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/358)
 - *Removed* redundant script for Apply Basic Damage macro (which uses DialogV1), which is superceded by the Damage Console (which uses AppV2). [#359](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/359)
-- *Fixed* ContextMenuEntry#callback deprecation warning when calling Edit Message Flavour in chatlog [#360](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/360)
+- *Fixed* ContextMenuEntry#callback deprecation warning when calling Edit Message Flavour in chatlog (v14). Maintains v13 compatibility for Edit Message Flavour ContextMenuEntry#callback. [#360](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/360) 
 
 
 ## [Version 9.2.0](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/v9.2.0)  (2026-05-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ See [Issue Backlog](../../issues) and [Roadmap](../../milestones).
 - *Fixed* renderTemplate deprecation warning when calling Advantage Momentum dialog. [#356](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/356)
 - *Changed* Toggle Scene Vision and Light macro to use scene environment data model `environment.globalLight.enabled`. [#357](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/357)
 - *Changed* Dark Whispers to use dataset actions for chat message intereactions rather than button attributes.  [#358](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/358)
-- Remove redundant script for Apply Basic Damage macro (which uses DialogV1), which is superceded by the Damage Console (which uses AppV2). [#359](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/359)
+- *Removed* redundant script for Apply Basic Damage macro (which uses DialogV1), which is superceded by the Damage Console (which uses AppV2). [#359](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/359)
+- *Fixed* ContextMenuEntry#callback deprecation warning when calling Edit Message Flavour in chatlog [#360](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/pull/360)
 
 
 ## [Version 9.2.0](https://github.com/Jagusti/fvtt-wfrp4e-gmtoolkit/releases/tag/v9.2.0)  (2026-05-24)

--- a/wfrp4e-gm-toolkit.mjs
+++ b/wfrp4e-gm-toolkit.mjs
@@ -153,48 +153,54 @@ Hooks.on("getChatMessageContextOptions", (html, options) => {
       name: game.i18n.localize("GMTOOLKIT.ChatFlavour.Title"),
       icon: '<i class="fas fa-pen-fancy"></i>',
       condition: game.user.isGM,
+      callback: li => {  // TODO: Remove deprecated v13 compatibility
+        _editMessage(game.messages.get(li.dataset.messageId))
+      },
       onClick: (event, target) => {
-        const message = game.messages.get(target.dataset.messageId)
-        let result
-        foundry.applications.api.DialogV2.wait({
-          window: { title: game.i18n.localize("GMTOOLKIT.ChatFlavour.Title") },
-          rejectClose: false,
-          content: `<form>
-                <div class="form-group">
-                  <input type="text"
-                    id="messageflavor"
-                    name="messageflavor"
-                    placeholder="${game.i18n.localize("GMTOOLKIT.ChatFlavour.Placeholder")}"
-                    value="${message?.flavor}"
-                  />
-                </div>
-                </form>`,
-          buttons: [
-            {
-              icon: "<i class='fas fa-check'></i>",
-              label: game.i18n.localize("GMTOOLKIT.Dialog.Apply"),
-              action: "apply",
-              default: "yes",
-              callback: (event, button, dialog) => {
-                result = new foundry.applications.ux
-                  .FormDataExtended(button.form).object
-              }
-            },
-            {
-              icon: "<i class='fas fa-times'></i>",
-              label: game.i18n.localize("GMTOOLKIT.Dialog.Cancel"),
-              action: "cancel"
-            }
-          ],
-          close: () => {
-            console.log(result)
-            if (result) {
-              const messageFlavor = result.messageflavor
-              message.update({ flavor: messageFlavor })
-            }
-          }
-        })
+        _editMessage(game.messages.get(target.dataset.messageId))
       }
     }
   )
+
+  function _editMessage (message) {
+    let result
+    foundry.applications.api.DialogV2.wait({
+      window: { title: game.i18n.localize("GMTOOLKIT.ChatFlavour.Title") },
+      rejectClose: false,
+      content: `<form>
+            <div class="form-group">
+              <input type="text"
+                id="messageflavor"
+                name="messageflavor"
+                placeholder="${game.i18n.localize("GMTOOLKIT.ChatFlavour.Placeholder")}"
+                value="${message?.flavor}"
+              />
+            </div>
+            </form>`,
+      buttons: [
+        {
+          icon: "<i class='fas fa-check'></i>",
+          label: game.i18n.localize("GMTOOLKIT.Dialog.Apply"),
+          action: "apply",
+          default: "yes",
+          callback: (event, button, dialog) => {
+            result = new foundry.applications.ux
+              .FormDataExtended(button.form).object
+          }
+        },
+        {
+          icon: "<i class='fas fa-times'></i>",
+          label: game.i18n.localize("GMTOOLKIT.Dialog.Cancel"),
+          action: "cancel"
+        }
+      ],
+      close: () => {
+        console.log(result)
+        if (result) {
+          const messageFlavor = result.messageflavor
+          message.update({ flavor: messageFlavor })
+        }
+      }
+    })
+  }
 })

--- a/wfrp4e-gm-toolkit.mjs
+++ b/wfrp4e-gm-toolkit.mjs
@@ -153,8 +153,8 @@ Hooks.on("getChatMessageContextOptions", (html, options) => {
       name: game.i18n.localize("GMTOOLKIT.ChatFlavour.Title"),
       icon: '<i class="fas fa-pen-fancy"></i>',
       condition: game.user.isGM,
-      callback: li => {
-        const message = game.messages.get(li.dataset.messageId)
+      onClick: (event, target) => {
+        const message = game.messages.get(target.dataset.messageId)
         let result
         foundry.applications.api.DialogV2.wait({
           window: { title: game.i18n.localize("GMTOOLKIT.ChatFlavour.Title") },


### PR DESCRIPTION
## Type of change
- [x]  Deprecation fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Translation (updates existing localization strings or adds complete new language file)
- [ ] Release (administrative update for tagged release, eg, changelog, readme, manifest)
- [ ] Maintenance (updates to the repository, dependencies and other non-functional code management)

## Summary of changes
Replaced ContextMenuEntry#callback with ContextMenuEntry#onClick. 
This is not recognised in FVTT v13, making this a potential breaking change. 
However, support is added for both versions, so this needs to be cleaned up when v13 support is removed. 

## Development / Testing Environment
- Foundry VTT: 13.346 | 14.363
- WFRP4e System: 9.1.4 | 9.6.1
- GM Toolkit: 9.2.0


